### PR TITLE
Intro Cutscene Fix v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ if(MSVC)
           ${DEFAULT_CXX_EXCEPTION_HANDLING}
       )
       target_compile_options(${PROJECT_NAME} PRIVATE  $<$<CONFIG:Debug>:/ZI;>)
+      target_compile_options(${PROJECT_NAME} PRIVATE  $<$<CONFIG:Release>:/Zi;>)
   elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
       target_compile_options(${PROJECT_NAME} PRIVATE
           $<$<CONFIG:Debug>:

--- a/src/engine/fox_radio.c
+++ b/src/engine/fox_radio.c
@@ -572,7 +572,6 @@ void Radio_Draw(void) {
         case 32:
             if (Audio_GetCurrentVoice() == 0) {
                 gRadioMsgListIndex++;
-                gRadioMsgId = 10 * (gRadioMsgListIndex + 1);
                 gRadioMsg = SEGMENTED_TO_VIRTUAL(gRadioMsgList[gRadioMsgListIndex]);
                 Audio_PlayVoice(Message_IdFromPtr(gRadioMsg));
                 gRadioMsgCharIndex = 0;
@@ -603,16 +602,15 @@ void Radio_Draw(void) {
             if (!(fakeTemp)) {
                 ret = Audio_GetCurrentVoiceStatus();
 
-                if (gRadioMsgId < 50) {
-                    if (gRadioMsg[gRadioMsgCharIndex + 1] == MSGCHAR_NXT) {
+                if (gRadioMsgCharIndex < 60) {
+                    if (gRadioMsg[gRadioMsgCharIndex + 1] == MSGCHAR_NXT && *gRadioMsg != 38) {
                         if (ret == 0) {
                             gRadioState = 31;
                         }
-                    } else {
+                    }
+                    else {
                         gRadioMsgCharIndex++;
                     }
-                } else {
-                    gRadioMsgCharIndex++;
                 }
 
                 if (sRadioCheckMouthFlag) {


### PR DESCRIPTION
First, this adds /Zi to release config on win64 for debugging info in release mode. Don't know why that wasn't getting set with the base CMake config like was working for SoH and 2S2H.

Doing so revealed that gRadioMsgId was always 0 in win64 release, and thus wasn't actually preventing the check causing radio state to be 31 to trigger the next messageList iteration, which after the last Pepper message in the intro, causes an oob if a random character during the check for MSGCHAR_NXT happened to match. This reverts most of those changes and excludes the last pepper message from that check by dereferenced gRadioMsg value instead. Should permanently resolve the issue while not affecting any other textboxes anymore.