### PR TITLE
Better Starfield Culling

### DIFF
--- a/src/engine/fox_bg.c
+++ b/src/engine/fox_bg.c
@@ -229,6 +229,12 @@ void Background_DrawStarfield(void) {
             FrameInterpolation_ShouldInterpolateFrame(false);
         }
 
+        float originalWidth = currentScreenWidth / 5;
+        float originalAspect = originalWidth / (currentScreenHeight / 3);
+        float renderMaskWidth = originalWidth * (OTRGetAspectRatio() / originalAspect);
+        float marginX = (currentScreenWidth - renderMaskWidth) / 2;
+        float renderMaskHeight = currentScreenHeight / 3;
+
         for (i = 0; i < starCount; i++, yStar++, xStar++, color++) {
             // Adjust star positions with field offsets
             bx = *xStar + xField;
@@ -257,12 +263,6 @@ void Background_DrawStarfield(void) {
             // Apply rotation
             vx = (zCos * bx) + (zSin * by) + currentScreenWidth / 2.0f;
             vy = (-zSin * bx) + (zCos * by) + currentScreenHeight / 2.0f;
-
-            float originalWidth = currentScreenWidth / 5;
-            float originalAspect = originalWidth / (currentScreenHeight / 3);
-            float renderMaskWidth = originalWidth * (OTRGetAspectRatio() / originalAspect);
-            float marginX = (currentScreenWidth - renderMaskWidth) / 2;
-            float renderMaskHeight = currentScreenHeight / 3;
 
             // Check if the star is within the visible screen area with margin
             if (vx >= (marginX - STAR_MARGIN) && vx <= (marginX + renderMaskWidth + STAR_MARGIN) &&

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -589,11 +589,3 @@ extern "C" void* GameEngine_Malloc(size_t size) {
     SPDLOG_INFO("Memory pool resized from {} to {}", MemoryPool.length - chunk, MemoryPool.length);
     return GameEngine_Malloc(size);
 }
-
-extern "C" float GetWindowWidth() {
-    return Ship::Context::GetInstance()->GetWindow()->GetWidth();
-}
-
-extern "C" float GetWindowHeight() {
-    return Ship::Context::GetInstance()->GetWindow()->GetHeight();
-}


### PR DESCRIPTION
Changes the render view calculations to make star skips more efficient. Because of the changes, I was able to remove the separate garbage star calculation and simplify the star interpolation exclusion functionality.

Here's an overview of the calculations: 320x240 (or aspect ratio of 1.33) is what the default viewport is. This uses the same pixelspace as `currentScreenWidth/Height`, which is now set to 5x original width (320) and 3x original height (240). `renderMaskWidth` is what translates the current window's aspect ratio to the render view, calculated by the originalWidth multiplied by the quotient between the current aspect ratio and the original aspect the renderMask needs to be based on. `marginX` is the space on either side for the width that is the difference between `renderMaskWidth` and `currentScreenWidth`. `renderMaskHeight` is basically a static variable, as the game's "window" is always based on 240.  Anything that is within the middle 240-pixel third of `currentScreenHeight` and the renderMaskWidth is shown, everything else is skipped.

This allows essentially 32:9 resolution on my laptop, which is very underpowered, with no slowdowns whatsoever, in release mode. This might actually warrant removing the starfield interp checkbox, as even in debug, normal resolutions have no slowdown on low-end hardware.