### PR TITLE
fix crash when interpolation enabled on linux

### DIFF
--- a/src/sys/sys_matrix.c
+++ b/src/sys/sys_matrix.c
@@ -32,8 +32,8 @@ Matrix* gGfxMatrix;
 Matrix sGfxMatrixStack[0x1000];
 Matrix* gCalcMatrix;
 Matrix sCalcMatrixStack[0x1000];
-Matrix* gInterpolationMatrix;
 Matrix sInterpolationMatrixStack[0x1000];
+Matrix* gInterpolationMatrix = &sInterpolationMatrixStack[0];
 
 // Copies src Matrix into dst
 void Matrix_Copy(Matrix* dst, Matrix* src) {


### PR DESCRIPTION
i'm not sure exactly what was going on, but we were getting bad pointers in a bunch of `sys_matrix` functions when transitioning between screens

all of those functions had `gInterpolationMatrix` passed in when they were called, and that should be set in

https://github.com/HarbourMasters/Starship/blob/537b25ab13ecd07146463711c576ed28cad72165/src/sys/sys_main.c#L151

so my *guess* is that we were sometimes getting to those functions before it was being set? (on scene transition of some sort?)

i wish i had a better understanding of why we were getting bad pointers, but doing this makes it so we don't get bad pointers and the game doesn't crash (and it's a tiny 1 line fix that seems reasonable so :shrug: i guess?) 