### PR TITLE
Display earned medals correctly in rankings menu

### DIFF
--- a/src/overlays/ovl_menu/fox_option.c
+++ b/src/overlays/ovl_menu/fox_option.c
@@ -2464,7 +2464,7 @@ void Option_RankingPlanetRoute_Draw(s32 rankIdx, f32 y, s32 routeMax) {
     static f32 xAdvance = 40.1f;
     s32 i;
     PlanetId planet;
-    bool gotMedal;
+    u16 gotMedal;
     bool drawPlanetMedal;
     f32 x;
     s32 pad[2];


### PR DESCRIPTION
Very small change, fixes #40.

Before:

![rankbefore](https://github.com/user-attachments/assets/df8c16c5-9535-4488-ba9f-1d556e778f79)

After:

![rankafter](https://github.com/user-attachments/assets/099e1cdd-351b-4bf3-9d1a-107e5fdd1aaf)
