### PR TITLE
Add Infinite Boost cheat

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -5069,7 +5069,10 @@ void Player_ArwingBoost(Player* player) {
         sp28 = 1.5f;
         sp2C = 0.35f;
     }
-
+    if (CVarGetInteger("gInfiniteBoost", 0)) {
+        sp28 = 0.0f;
+    } 
+    
     player->sfx.boost = 0;
 
     stickY = gInputPress->stick_y; // fake?
@@ -5198,7 +5201,10 @@ void Player_ArwingBrake(Player* player) {
     } else {
         sp30 = 1.5f;
         sp34 = 0.35f;
-    }
+    }    
+    if (CVarGetInteger("gInfiniteBoost", 0)) {
+        sp30 = 0.0f;
+    } 
 
     player->sfx.brake = false;
 

--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -5201,7 +5201,7 @@ void Player_ArwingBrake(Player* player) {
     } else {
         sp30 = 1.5f;
         sp34 = 0.35f;
-    }    
+    }
     if (CVarGetInteger("gInfiniteBoost", 0)) {
         sp30 = 0.0f;
     } 

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -1120,10 +1120,12 @@ void Tank_UpdateOnRails(Player* player) {
     func_tank_80045348(player);
     if (!player->boostCooldown) {
         if (D_800C9F14 != 0) {
-            if (D_800C9F14 >= 2) {
-                player->boostMeter += 2.0f;
-            } else {
-                player->boostMeter += 1.0f;
+            if (!CVarGetInteger("gInfiniteBoost", 0)) {
+                if (D_800C9F14 >= 2) {
+                    player->boostMeter += 2.0f;
+                } else {
+                    player->boostMeter += 1.0f;
+                }
             }
             if (player->boostMeter > 90.0f) {
                 player->boostMeter = 90.0f;

--- a/src/overlays/ovl_i3/fox_aq.c
+++ b/src/overlays/ovl_i3/fox_aq.c
@@ -1522,6 +1522,7 @@ void Aquas_BlueMarineBoost(Player* player) {
                     player->boostCooldown = 1;
                 }
             }
+
             player->boostSpeed += 2.0f;
             if (player->boostSpeed > 10.0f) {
                 player->boostSpeed = 10.0f;
@@ -1571,6 +1572,7 @@ void Aquas_BlueMarineBrake(Player* player) {
                 player->boostCooldown = 1;
             }
         }
+
         player->boostSpeed -= 1.0f;
         if (player->boostSpeed < -20.0f) {
             player->boostSpeed = -20.0f;

--- a/src/overlays/ovl_i3/fox_aq.c
+++ b/src/overlays/ovl_i3/fox_aq.c
@@ -1515,12 +1515,13 @@ void Aquas_BlueMarineBoost(Player* player) {
                 AUDIO_PLAY_SFX(NA_SE_MARINE_BOOST, player->sfxSource, 4);
             }
 
-            player->boostMeter += 3.0f;
-            if (player->boostMeter > 90.0f) {
-                player->boostMeter = 90.0f;
-                player->boostCooldown = 1;
+            if (!CVarGetInteger("gInfiniteBoost", 0)) {
+                player->boostMeter += 3.0f;
+                if (player->boostMeter > 90.0f) {
+                    player->boostMeter = 90.0f;
+                    player->boostCooldown = 1;
+                }
             }
-
             player->boostSpeed += 2.0f;
             if (player->boostSpeed > 10.0f) {
                 player->boostSpeed = 10.0f;
@@ -1563,12 +1564,13 @@ void Aquas_BlueMarineBrake(Player* player) {
             AUDIO_PLAY_SFX(NA_SE_MARINE_BRAKE, player->sfxSource, 4);
         }
 
-        player->boostMeter += 3.0f;
-        if (player->boostMeter > 90.0f) {
-            player->boostMeter = 90.0f;
-            player->boostCooldown = 1;
+        if (!CVarGetInteger("gInfiniteBoost", 0)) {
+            player->boostMeter += 3.0f;
+            if (player->boostMeter > 90.0f) {
+                player->boostMeter = 90.0f;
+                player->boostCooldown = 1;
+            }
         }
-
         player->boostSpeed -= 1.0f;
         if (player->boostSpeed < -20.0f) {
             player->boostSpeed = -20.0f;

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -476,6 +476,7 @@ void DrawCheatsMenu() {
         UIWidgets::CVarCheckbox("Invincible", "gInvincible");
         UIWidgets::CVarCheckbox("Unbreakable Wings", "gUnbreakableWings");
         UIWidgets::CVarCheckbox("Infinite Bombs", "gInfiniteBombs");
+        UIWidgets::CVarCheckbox("Infinite Boost/Brake", "gInfiniteBoost");
         UIWidgets::CVarCheckbox("Hyper Laser", "gHyperLaser");
         UIWidgets::CVarCheckbox("Self destruct button", "gHit64SelfDestruct", {
                 .tooltip = "Press Down on the D-PAD to instantly self destruct."


### PR DESCRIPTION
I made sure it works on the Arwing (Rails and  All Range Mode), Landmaster and the Blue Marine. 

Apparently the `Player_TankBoostBrake(player)` function in `fox_play.c` is only for Landmaster on All Range Mode, which doesn't exist in single-player. Since Multiplayer is not supported, I did not modify that function as I could not be sure it worked. 