### PR TITLE
Optional tweak to penalize player score for Friendly Fire on Katina

### DIFF
--- a/src/engine/fox_360.c
+++ b/src/engine/fox_360.c
@@ -993,6 +993,9 @@ void ActorAllRange_ApplyDamage(ActorAllRange* this) {
                     if (gKaAllyKillCount < 2) {
                         ActorAllRange_PlayMessage(gMsg_ID_18018, RCID_BILL);
                     }
+                    if (CVarGetInteger("gKatinaPunishFF", 0) == 1 && gHitCount > 0) {
+                        gHitCount--;
+                    }
                     gKaAllyKillCount++;
                 }
                 switch (this->aiType) {

--- a/src/engine/fox_hud.c
+++ b/src/engine/fox_hud.c
@@ -5503,13 +5503,18 @@ void HUD_Score_Draw(f32 x, f32 y) {
     f32 x1;
     f32 y1;
     f32 xScale;
+    bool decrease = false;
 
     x = OTRGetDimensionFromLeftEdge(x);
 
     if (gHitCount > gDisplayedHitCount) {
         temp3 = gDisplayedHitCount + 1;
         temp4 = gDisplayedHitCount;
-    } else {
+    } else if (gHitCount < gDisplayedHitCount) {
+        decrease = true;
+        temp3 = gDisplayedHitCount - 1;
+        temp4 = gDisplayedHitCount;
+    } else{
         temp3 = gHitCount;
         temp4 = gDisplayedHitCount;
     }
@@ -5519,6 +5524,7 @@ void HUD_Score_Draw(f32 x, f32 y) {
     temp3 %= i;
     temp4 %= i;
 
+    //Loop runs three times with i == 100, 10, and 1. For each digit of the score counter. 
     for (i /= 10, j = 0; i != 1; i /= 10, j++) {
         xScale = 1.0f;
         x1 = x;
@@ -5592,7 +5598,11 @@ void HUD_Score_Draw(f32 x, f32 y) {
         }
 
         if (D_hud_80161720[j] >= 2.0f) {
-            temp4++;
+            if (decrease) {
+                temp4--;
+            } else {
+                temp4++;
+            }
             if (temp4 >= 10) {
                 temp4 = 0;
             }
@@ -5600,7 +5610,11 @@ void HUD_Score_Draw(f32 x, f32 y) {
         }
 
         if ((D_hud_80161720[j] < 2.0f) && (D_hud_80161720[j] >= 1.1f)) {
-            temp4++;
+            if (decrease) {
+                temp4--;
+            } else {
+                temp4++;
+            }
             if (temp4 >= 10) {
                 temp4 = 0;
             }
@@ -5617,7 +5631,11 @@ void HUD_Score_Draw(f32 x, f32 y) {
 
     if ((gHitCount != gDisplayedHitCount) && (D_hud_80161720[0] == 0.0f) && (D_hud_80161720[1] == 0.0f) &&
         (D_hud_80161720[2] == 0.0f)) {
-        gDisplayedHitCount++;
+        if (decrease){
+            gDisplayedHitCount--;
+        } else {
+            gDisplayedHitCount++;
+        }
 
         if ((gDisplayedHitCount == 4) || (gDisplayedHitCount == 9) || (gDisplayedHitCount == 14) ||
             (gDisplayedHitCount == 19) || (gDisplayedHitCount == 24) || (gDisplayedHitCount == 29)) {

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -446,6 +446,10 @@ void DrawEnhancementsMenu() {
                 .tooltip = "Character heads are displayed inside Arwings in all cutscenes",
                 .defaultValue = true
             });
+            UIWidgets::CVarCheckbox("Score penalty on Katina Friendly Fire", "gKatinaPunishFF", {
+                .tooltip = "Shooting down a friendly fighter on Katina reduces your score.",
+                .defaultValue = false
+            });
 
             ImGui::EndMenu();
         }

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -446,10 +446,6 @@ void DrawEnhancementsMenu() {
                 .tooltip = "Character heads are displayed inside Arwings in all cutscenes",
                 .defaultValue = true
             });
-            UIWidgets::CVarCheckbox("Score penalty on Katina Friendly Fire", "gKatinaPunishFF", {
-                .tooltip = "Shooting down a friendly fighter on Katina reduces your score.",
-                .defaultValue = false
-            });
 
             ImGui::EndMenu();
         }
@@ -501,6 +497,18 @@ void DrawCheatsMenu() {
             UIWidgets::CVarSliderInt("Score: %d", "gScoreEditValue", 0, 999, 0,
                 { .tooltip = "Increase or decrease the current mission score number" });
         }
+
+        ImGui::EndMenu();
+    }
+}
+
+void DrawModsMenu() {
+    if (UIWidgets::BeginMenu("Mods")) {
+        UIWidgets::CVarCheckbox("Score penalty on Katina Friendly Fire", "gKatinaPunishFF", {
+            .tooltip = "Shooting down a friendly fighter on Katina reduces your score.",
+            .defaultValue = false
+        });
+
 
         ImGui::EndMenu();
     }
@@ -645,6 +653,8 @@ void GameMenuBar::DrawElement() {
         DrawCheatsMenu();
 
         ImGui::SetCursorPosY(0.0f);
+
+        DrawModsMenu();
 
         ImGui::SetCursorPosY(0.0f);
 


### PR DESCRIPTION
This adds an optional tweak that causes players to lose points when they shoot down allies in Katina. 
It's set to *off* by default. 
I've made sure to prevent underflowing (it checks if your score is bigger than zero before trying to subtract)

As an added bonus, this fixes a bug with the Score Editor, which would spin like crazy if you set the value to lower than the current score. 

![Screenshot from 2024-12-26 20-58-27](https://github.com/user-attachments/assets/be12ce4d-b2e8-4440-a75f-04557be662ab)

https://github.com/user-attachments/assets/a6dc5fc0-5323-4e60-85dc-097f99b21251

