### PR TITLE
Reorder PLANET_STATS()

### DIFF
--- a/include/sf64save.h
+++ b/include/sf64save.h
@@ -32,7 +32,7 @@ typedef struct PlanetStats {
 
 #define PLANET_STATS(hitCount, planetId, peppyAlive, falcoAlive, slippyAlive) \
     (hitCount > 255 ? hitCount - 256 : hitCount),                             \
-        ((planetId << 4) | ((hitCount > 255 ? 1 : 0) << 3) | (peppyAlive << 2) | (falcoAlive << 1) | (slippyAlive))
+        ((planetId) | ((hitCount > 255 ? 1 : 0) << 4) | (peppyAlive << 5) | (falcoAlive << 6) | (slippyAlive << 7))
 
 typedef struct SaveData {
     /* 0x00 */ PlanetData planet[16];


### PR DESCRIPTION
Ranking data created with PLANET_STATS() doesn't match data constructed with the PlanetStats struct, possibly due to a difference in endianness between platforms. I've elected to reorder the bits in PLANET_STATS() instead of the struct so that player-made rankings won't break.

Fixes #67 for new save files.