### PR TITLE
Add option to invert Y axis

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -3700,7 +3700,7 @@ void Player_MoveArwing360(Player* player) {
 
     sp7C = -gInputPress->stick_x;
     
-    sp78 = gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
+    sp78 = gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 1 ? -1 : 1);
 
     Math_SmoothStepToAngle(&player->aerobaticPitch, 0.0f, 0.1f, 5.0f, 0.01f);
     Matrix_RotateZ(gCalcMatrix, -player->zRotBank * M_DTOR, MTXF_NEW);
@@ -3946,7 +3946,7 @@ void Player_MoveArwingOnRails(Player* player) {
     }
 
     stickX = -gInputPress->stick_x;
-    stickY = gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
+    stickY = gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 1 ? -1 : 1);
 
     Math_SmoothStepToAngle(&player->aerobaticPitch, 0.0f, 0.1f, 5.0f, 0.01f);
 

--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -3699,7 +3699,9 @@ void Player_MoveArwing360(Player* player) {
     gPlayerTurnStickMod = 0.68f;
 
     sp7C = -gInputPress->stick_x;
-    sp78 = gInputPress->stick_y;
+    
+    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
+    sp78 = gInputPress->stick_y * YAxisMult;
 
     Math_SmoothStepToAngle(&player->aerobaticPitch, 0.0f, 0.1f, 5.0f, 0.01f);
     Matrix_RotateZ(gCalcMatrix, -player->zRotBank * M_DTOR, MTXF_NEW);
@@ -3945,7 +3947,9 @@ void Player_MoveArwingOnRails(Player* player) {
     }
 
     stickX = -gInputPress->stick_x;
-    stickY = +gInputPress->stick_y;
+
+    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
+    stickY = gInputPress->stick_y * YAxisMult;
 
     Math_SmoothStepToAngle(&player->aerobaticPitch, 0.0f, 0.1f, 5.0f, 0.01f);
 

--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -3700,8 +3700,7 @@ void Player_MoveArwing360(Player* player) {
 
     sp7C = -gInputPress->stick_x;
     
-    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
-    sp78 = gInputPress->stick_y * YAxisMult;
+    sp78 = gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
 
     Math_SmoothStepToAngle(&player->aerobaticPitch, 0.0f, 0.1f, 5.0f, 0.01f);
     Matrix_RotateZ(gCalcMatrix, -player->zRotBank * M_DTOR, MTXF_NEW);
@@ -3947,9 +3946,7 @@ void Player_MoveArwingOnRails(Player* player) {
     }
 
     stickX = -gInputPress->stick_x;
-
-    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
-    stickY = gInputPress->stick_y * YAxisMult;
+    stickY = gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
 
     Math_SmoothStepToAngle(&player->aerobaticPitch, 0.0f, 0.1f, 5.0f, 0.01f);
 

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -380,7 +380,7 @@ void func_tank_80044868(Player* player) {
     f32 stickTilt;
     f32 sp2C;
 
-    stickTilt = (gInputPress->stick_y * 0.7f * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1)) - 8.0f;
+    stickTilt = (gInputPress->stick_y * 0.7f * (CVarGetInteger("gInvertYAxis", 0) == 1 ? -1 : 1)) - 8.0f;
     if (stickTilt < -40.0f) {
         stickTilt = -40.0f;
     }
@@ -665,7 +665,7 @@ void func_tank_80045678(Player* player) {
         }
         player->zRotBank += ((__cosf(gGameFrameCount * M_DTOR * 8.0f) * 10.0f) - player->zRotBank) * 0.1f;
 
-        temp = -gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
+        temp = -gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 1 ? -1 : 1);
         Math_SmoothStepToF(&player->rot.x, temp * 0.3f, 0.05f, 5.0f, 0.00001f);
         Math_SmoothStepToF(&player->boostSpeed, 15.0f, 0.5f, 5.0f, 0.0f);
         Math_SmoothStepToF(&player->rot.z, 0.0f, 0.1f, 5.0f, 0.00001f);

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -380,8 +380,7 @@ void func_tank_80044868(Player* player) {
     f32 stickTilt;
     f32 sp2C;
 
-    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
-    stickTilt = (gInputPress->stick_y * 0.7f * YAxisMult) - 8.0f;
+    stickTilt = (gInputPress->stick_y * 0.7f * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1)) - 8.0f;
     if (stickTilt < -40.0f) {
         stickTilt = -40.0f;
     }
@@ -666,8 +665,7 @@ void func_tank_80045678(Player* player) {
         }
         player->zRotBank += ((__cosf(gGameFrameCount * M_DTOR * 8.0f) * 10.0f) - player->zRotBank) * 0.1f;
 
-        s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
-        temp = -gInputPress->stick_y * YAxisMult;
+        temp = -gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
         Math_SmoothStepToF(&player->rot.x, temp * 0.3f, 0.05f, 5.0f, 0.00001f);
         Math_SmoothStepToF(&player->boostSpeed, 15.0f, 0.5f, 5.0f, 0.0f);
         Math_SmoothStepToF(&player->rot.z, 0.0f, 0.1f, 5.0f, 0.00001f);

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -380,7 +380,8 @@ void func_tank_80044868(Player* player) {
     f32 stickTilt;
     f32 sp2C;
 
-    stickTilt = (gInputPress->stick_y * 0.7f) - 8.0f;
+    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
+    stickTilt = (gInputPress->stick_y * 0.7f * YAxisMult) - 8.0f;
     if (stickTilt < -40.0f) {
         stickTilt = -40.0f;
     }
@@ -664,7 +665,9 @@ void func_tank_80045678(Player* player) {
             AUDIO_PLAY_SFX(NA_SE_TANK_GO_UP, player->sfxSource, 0);
         }
         player->zRotBank += ((__cosf(gGameFrameCount * M_DTOR * 8.0f) * 10.0f) - player->zRotBank) * 0.1f;
-        temp = -gInputPress->stick_y;
+
+        s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
+        temp = -gInputPress->stick_y * YAxisMult;
         Math_SmoothStepToF(&player->rot.x, temp * 0.3f, 0.05f, 5.0f, 0.00001f);
         Math_SmoothStepToF(&player->boostSpeed, 15.0f, 0.5f, 5.0f, 0.0f);
         Math_SmoothStepToF(&player->rot.z, 0.0f, 0.1f, 5.0f, 0.00001f);

--- a/src/overlays/ovl_i3/fox_aq.c
+++ b/src/overlays/ovl_i3/fox_aq.c
@@ -803,7 +803,8 @@ void Aquas_801AA4BC(Player* player) {
 
 void Aquas_UpdateCamera(Player* player) {
     f32 stickX = +gInputPress->stick_x;
-    f32 stickY = -gInputPress->stick_y;
+    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
+    f32 stickY = -gInputPress->stick_y * YAxisMult;
     f32 zRot;
 
     if (player->state != PLAYERSTATE_ACTIVE) {
@@ -877,7 +878,9 @@ void Aquas_BlueMarineMove(Player* player) {
     Aquas_801A8E30();
 
     stickX = -gInputPress->stick_x;
-    stickY = +gInputPress->stick_y;
+
+    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
+    stickY = +gInputPress->stick_y * YAxisMult;
 
     gPlayerTurnStickMod = 0.68f;
 

--- a/src/overlays/ovl_i3/fox_aq.c
+++ b/src/overlays/ovl_i3/fox_aq.c
@@ -803,8 +803,7 @@ void Aquas_801AA4BC(Player* player) {
 
 void Aquas_UpdateCamera(Player* player) {
     f32 stickX = +gInputPress->stick_x;
-    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
-    f32 stickY = -gInputPress->stick_y * YAxisMult;
+    f32 stickY = -gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
     f32 zRot;
 
     if (player->state != PLAYERSTATE_ACTIVE) {
@@ -879,8 +878,7 @@ void Aquas_BlueMarineMove(Player* player) {
 
     stickX = -gInputPress->stick_x;
 
-    s8 YAxisMult = CVarGetInteger("gInvertYAxis", 0) ? -1 : 1;
-    stickY = +gInputPress->stick_y * YAxisMult;
+    stickY = +gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
 
     gPlayerTurnStickMod = 0.68f;
 

--- a/src/overlays/ovl_i3/fox_aq.c
+++ b/src/overlays/ovl_i3/fox_aq.c
@@ -803,7 +803,7 @@ void Aquas_801AA4BC(Player* player) {
 
 void Aquas_UpdateCamera(Player* player) {
     f32 stickX = +gInputPress->stick_x;
-    f32 stickY = -gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
+    f32 stickY = -gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 1 ? -1 : 1);
     f32 zRot;
 
     if (player->state != PLAYERSTATE_ACTIVE) {
@@ -878,7 +878,7 @@ void Aquas_BlueMarineMove(Player* player) {
 
     stickX = -gInputPress->stick_x;
 
-    stickY = +gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 0 ? 1 : -1);
+    stickY = +gInputPress->stick_y * (CVarGetInteger("gInvertYAxis", 0) == 1 ? -1 : 1);
 
     gPlayerTurnStickMod = 0.68f;
 

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -186,6 +186,9 @@ void DrawSettingsMenu(){
                     .format = "%.1fx",
                 });
             }
+            UIWidgets::CVarCheckbox("Invert Y Axis", "gInvertYAxis",{
+                .tooltip = "Inverts the Y axis for controlling vehicles"
+            });
 
             ImGui::EndMenu();
         }


### PR DESCRIPTION
Adds an option that inverts the Y-Axis in gameplay, without affecting menus and other parts where the player would use the control stick. Tested with all 3 vehicles, and both rails and 360.
![image](https://github.com/user-attachments/assets/5b5f8872-f906-4fb2-aa44-4a504b483b30)
