### PR TITLE
Enhancement: Skip credits

### DIFF
--- a/src/overlays/ovl_ending/fox_end1.c
+++ b/src/overlays/ovl_ending/fox_end1.c
@@ -1027,6 +1027,17 @@ void Ending_Main(void) {
     gCsFrameCount++;
     gGameFrameCount++;
 
+    if (CVarGetInteger("gSkipCredits", 0)) {
+        gControllerLock = 0;
+        if (gControllerPress[0].button & START_BUTTON) {
+            D_ending_80196D00 = 7;
+            D_ending_80196D04 = 7200;
+            D_ending_80192E70 = 7200;
+        }
+    } else {
+        gControllerLock = 10000;
+    }
+
     switch (D_ending_80196D00) {
         case 0:
             gRadioState = 0;
@@ -1150,6 +1161,10 @@ void Ending_Draw(void) {
 }
 
 void Ending_8018ABE8(void) {
+    if (CVarGetInteger("gSkipCredits", 0)) {
+        return;
+    }
+
     if (gControllerPress[3].button & Z_TRIG) {
         D_ending_80198584 ^= 1;
     }
@@ -1356,6 +1371,10 @@ void Ending_8018B174(Vec3f* actorPos, Vec3f* actorRot, f32* actorScale) {
     Vec3f pos = *actorPos;
     Vec3f sp1C = *actorRot;
     scale = *actorScale;
+
+    if (CVarGetInteger("gSkipCredits", 0)) {
+        return;
+    }
 
     if (gControllerHold[2].button & Z_TRIG) {
         if (gControllerHold[2].button & R_CBUTTONS) {

--- a/src/overlays/ovl_ending/fox_end2.c
+++ b/src/overlays/ovl_ending/fox_end2.c
@@ -1082,7 +1082,9 @@ void Ending_801924EC(u32 arg0) {
 }
 
 void Ending_801926D4(void) {
-    gControllerLock = 10000;
+    if (!CVarGetInteger("gSkipCredits", 0)) {
+        gControllerLock = 10000;
+    }
 
     Matrix_Push(&gGfxMatrix);
 

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -449,6 +449,15 @@ void DrawEnhancementsMenu() {
 
             ImGui::EndMenu();
         }
+
+        if (UIWidgets::BeginMenu("Cutscenes")) {
+            UIWidgets::CVarCheckbox("Skip Credits", "gSkipCredits", {
+                .tooltip = "Allows skipping credits by pressing the START button",
+                .defaultValue = true
+            });
+
+            ImGui::EndMenu();
+        }
         
         if (UIWidgets::BeginMenu("Fixes")) {
             UIWidgets::CVarCheckbox("Macbeth: Level ending cutscene camera fix", "gMaCameraFix", {


### PR DESCRIPTION
When enabled, credits can be skipped by pressing START on controller 1.
I added a new enhancement section for this setting because I felt it didn't belong in "Gameplay" or the debug/cheats menu.