### PR TITLE
Align ring count to right edge

### DIFF
--- a/src/overlays/ovl_i1/fox_tr.c
+++ b/src/overlays/ovl_i1/fox_tr.c
@@ -9,7 +9,7 @@
 
 void Training_RingPassCount_Draw(void) {
     if (gRingPassCount != 0) {
-        RCP_SetupDL(&gMasterDisp, SETUPDL_83);
+        RCP_SetupDL(&gMasterDisp, SETUPDL_83_POINT);
         gDPSetPrimColor(gMasterDisp++, 0, 0, 255, 255, 255, 255);
         HUD_Number_Draw(OTRGetDimensionFromRightEdge(250.0f), 50.0f, gRingPassCount, 1.0f, 0, 999);
     }

--- a/src/overlays/ovl_i1/fox_tr.c
+++ b/src/overlays/ovl_i1/fox_tr.c
@@ -11,7 +11,7 @@ void Training_RingPassCount_Draw(void) {
     if (gRingPassCount != 0) {
         RCP_SetupDL(&gMasterDisp, SETUPDL_83);
         gDPSetPrimColor(gMasterDisp++, 0, 0, 255, 255, 255, 255);
-        HUD_Number_Draw(250.0f, 50.0f, gRingPassCount, 1.0f, 0, 999);
+        HUD_Number_Draw(OTRGetDimensionFromRightEdge(250.0f), 50.0f, gRingPassCount, 1.0f, 0, 999);
     }
 }
 


### PR DESCRIPTION
Small change to get that number aligned properly in training mode.

Before:
![before](https://github.com/user-attachments/assets/65f7a2e7-ba53-4b5a-a73c-afc041c42e76)

After:
![after](https://github.com/user-attachments/assets/f9c7af53-07e4-42dc-9d3a-1d5db888248d)
