### PR TITLE
Prevent loading checkpoints in the wrong level

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -4648,10 +4648,15 @@ void Player_Setup(Player* playerx) {
     gDisplayedHitCount = gHitCount;
     D_hud_80161730 = 0;
 
-    if (CVarGetInteger("gCheckpoint.Set", 0) && CVarGetInteger("gCheckpoint.gSavedLevel", -1) == gCurrentLevel) {
-        gSavedGroundSurface = CVarGetInteger("gCheckpoint.gSavedGroundSurface", gSavedGroundSurface);
-        gSavedPathProgress = CVarGetFloat("gCheckpoint.gSavedPathProgress", gSavedPathProgress);
-        gSavedObjectLoadIndex = CVarGetInteger("gCheckpoint.gSavedObjectLoadIndex", gSavedObjectLoadIndex);
+    char buffer [48] = {"\0"};
+    sprintf(buffer, "gCheckpoint.%d.Set", gCurrentLevel);
+    if (CVarGetInteger(buffer, 0)) {
+        sprintf(buffer, "gCheckpoint.%d.gSavedGroundSurface", gCurrentLevel);
+        gSavedGroundSurface = CVarGetInteger(buffer, gSavedGroundSurface);
+        sprintf(buffer, "gCheckpoint.%d.gSavedPathProgress", gCurrentLevel);
+        gSavedPathProgress = CVarGetFloat(buffer, gSavedPathProgress);
+        sprintf(buffer, "gCheckpoint.%d.gSavedObjectLoadIndex", gCurrentLevel);
+        gSavedObjectLoadIndex = CVarGetInteger(buffer, gSavedObjectLoadIndex);
     }
 
     gMissedZoSearchlight = gSavedZoSearchlightStatus;

--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -4648,7 +4648,7 @@ void Player_Setup(Player* playerx) {
     gDisplayedHitCount = gHitCount;
     D_hud_80161730 = 0;
 
-    if (CVarGetInteger("gCheckpoint.Set", 0)) {
+    if (CVarGetInteger("gCheckpoint.Set", 0) && CVarGetInteger("gCheckpoint.gSavedLevel", -1) == gCurrentLevel) {
         gSavedGroundSurface = CVarGetInteger("gCheckpoint.gSavedGroundSurface", gSavedGroundSurface);
         gSavedPathProgress = CVarGetFloat("gCheckpoint.gSavedPathProgress", gSavedPathProgress);
         gSavedObjectLoadIndex = CVarGetInteger("gCheckpoint.gSavedObjectLoadIndex", gSavedObjectLoadIndex);

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -12,6 +12,7 @@
 #include <Fast3D/gfx_pc.h>
 #include "port/Engine.h"
 #include "port/notification/notification.h"
+#include "utils/StringHelper.h"
 
 extern "C" {
 #include "sys.h"
@@ -597,28 +598,17 @@ void DrawDebugMenu() {
             .tooltip = "Jump to credits at the main menu"
         });
 
-        if (CVarGetInteger("gCheckpoint.Set", 0)) {            
-            LevelId savedLevel = CVarGetInteger("gCheckpoint.gSavedLevel", -1);
-            std::string CheckpointLabel = "Checkpoint is at ";
-            if (savedLevel == 77){
-                CheckpointLabel += "Warp Zone";
-            } else if (savedLevel < 0 || savedLevel >= sizeof(GameUI::LevelNameLookup)/sizeof(GameUI::LevelNameLookup[0])) {
-                CheckpointLabel += "Unknown (out of bounds)";
-            } else {
-                CheckpointLabel += GameUI::LevelNameLookup[CVarGetInteger("gCheckpoint.gSavedLevel", -1)];
-            }
-            ImGui::Text(CheckpointLabel.c_str());
+        if (CVarGetInteger(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str(), 0)) {
             if (UIWidgets::Button("Clear Checkpoint")) {
-                CVarClear("gCheckpoint.Set");
+                CVarClear(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str());
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
             }
-        } else if (gPlayer != NULL) {
+        } else if (gPlayer != NULL && gGameState == GSTATE_PLAY) {
             if (UIWidgets::Button("Set Checkpoint")) {
-                CVarSetInteger("gCheckpoint.Set", 1);
-                CVarSetInteger("gCheckpoint.gSavedLevel", gCurrentLevel);
-                CVarSetInteger("gCheckpoint.gSavedPathProgress", gGroundSurface);
-                CVarSetFloat("gCheckpoint.gSavedPathProgress", (-gPlayer->pos.z) - 250.0f);
-                CVarSetInteger("gCheckpoint.gSavedObjectLoadIndex", gObjectLoadIndex);
+                CVarSetInteger(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str(), 1);
+                CVarSetInteger(StringHelper::Sprintf("gCheckpoint.%d.gSavedPathProgress", gCurrentLevel).c_str(), gGroundSurface);
+                CVarSetFloat(StringHelper::Sprintf("gCheckpoint.%d.gSavedPathProgress", gCurrentLevel).c_str(), (-gPlayer->pos.z) - 250.0f);
+                CVarSetInteger(StringHelper::Sprintf("gCheckpoint.%d.gSavedObjectLoadIndex", gCurrentLevel).c_str(), gObjectLoadIndex);
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
             }
         }

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -597,7 +597,17 @@ void DrawDebugMenu() {
             .tooltip = "Jump to credits at the main menu"
         });
 
-        if (CVarGetInteger("gCheckpoint.Set", 0)) {
+        if (CVarGetInteger("gCheckpoint.Set", 0)) {            
+            LevelId savedLevel = CVarGetInteger("gCheckpoint.gSavedLevel", -1);
+            std::string CheckpointLabel = "Checkpoint is at ";
+            if (savedLevel == 77){
+                CheckpointLabel += "Warp Zone";
+            } else if (savedLevel < 0 || savedLevel >= sizeof(GameUI::LevelNameLookup)/sizeof(GameUI::LevelNameLookup[0])) {
+                CheckpointLabel += "Unknown (out of bounds)";
+            } else {
+                CheckpointLabel += GameUI::LevelNameLookup[CVarGetInteger("gCheckpoint.gSavedLevel", -1)];
+            }
+            ImGui::Text(CheckpointLabel.c_str());
             if (UIWidgets::Button("Clear Checkpoint")) {
                 CVarClear("gCheckpoint.Set");
                 Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
@@ -605,6 +615,7 @@ void DrawDebugMenu() {
         } else if (gPlayer != NULL) {
             if (UIWidgets::Button("Set Checkpoint")) {
                 CVarSetInteger("gCheckpoint.Set", 1);
+                CVarSetInteger("gCheckpoint.gSavedLevel", gCurrentLevel);
                 CVarSetInteger("gCheckpoint.gSavedPathProgress", gGroundSurface);
                 CVarSetFloat("gCheckpoint.gSavedPathProgress", (-gPlayer->pos.z) - 250.0f);
                 CVarSetInteger("gCheckpoint.gSavedObjectLoadIndex", gObjectLoadIndex);

--- a/src/port/ui/ImguiUI.h
+++ b/src/port/ui/ImguiUI.h
@@ -2,15 +2,6 @@
 #include <libultraship/libultraship.h>
 
 namespace GameUI {
-    const std::string LevelNameLookup[] = 
-      { 
-        "Corneria", "Meteo", "Sector X", "Area 6", 
-        "Unknown", "Sector Y", "Venom 1", "Solar", 
-        "Zoness", "Andross", "Training", "Macbeth", 
-        "Titania", "Aquas", "Fortuna", "Unknown", 
-        "Katina", "Bolse", "Sector Z", "Venom 2", 
-        "Versus"
-      };
     void SetupGuiElements();
     void Destroy();
 }

--- a/src/port/ui/ImguiUI.h
+++ b/src/port/ui/ImguiUI.h
@@ -2,6 +2,15 @@
 #include <libultraship/libultraship.h>
 
 namespace GameUI {
+    const std::string LevelNameLookup[] = 
+      { 
+        "Corneria", "Meteo", "Sector X", "Area 6", 
+        "Unknown", "Sector Y", "Venom 1", "Solar", 
+        "Zoness", "Andross", "Training", "Macbeth", 
+        "Titania", "Aquas", "Fortuna", "Unknown", 
+        "Katina", "Bolse", "Sector Z", "Venom 2", 
+        "Versus"
+      };
     void SetupGuiElements();
     void Destroy();
 }


### PR DESCRIPTION
When a checkpoint is created via the Developer Menu, it now stores the info of what level it was created at, and checks that against `gCurrentLevel` upon trying to load a checkpoint.

Additionally, if a checkpoint is set, it now shows which level it is in.

![image](https://github.com/user-attachments/assets/b185bbb8-0e8a-4627-bff0-beb36245ce2d)
