### PR TITLE
Move Infinite Boost to hooks system

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -5105,9 +5105,6 @@ void Player_ArwingBoost(Player* player) {
         sp28 = 1.5f;
         sp2C = 0.35f;
     }
-    if (CVarGetInteger("gInfiniteBoost", 0)) {
-        sp28 = 0.0f;
-    } 
     
     player->sfx.boost = 0;
 
@@ -5240,9 +5237,6 @@ void Player_ArwingBrake(Player* player) {
         sp30 = 1.5f;
         sp34 = 0.35f;
     }
-    if (CVarGetInteger("gInfiniteBoost", 0)) {
-        sp30 = 0.0f;
-    } 
 
     player->sfx.brake = false;
 
@@ -5856,7 +5850,7 @@ void Player_Update(Player* player) {
     s32 i;
     Vec3f sp58[30];
     s32 pad;
-
+    CALL_EVENT(PlayerPreUpdateEvent, player);
     if (gVersusMode) {
         gInputHold = &gControllerHold[player->num];
         gInputPress = &gControllerPress[player->num];
@@ -6184,6 +6178,7 @@ void Player_Update(Player* player) {
         Math_SmoothStepToF(&player->unk_194, player->unk_190, 0.5f, 0.5f, 0.0f);
         player->unk_190 = 0.0f;
     }
+    CALL_EVENT(PlayerPostUpdateEvent, player);
 }
 
 void Camera_UpdateArwingOnRails(Player* player) {

--- a/src/engine/fox_tank.c
+++ b/src/engine/fox_tank.c
@@ -1126,12 +1126,10 @@ void Tank_UpdateOnRails(Player* player) {
     func_tank_80045348(player);
     if (!player->boostCooldown) {
         if (D_800C9F14 != 0) {
-            if (!CVarGetInteger("gInfiniteBoost", 0)) {
-                if (D_800C9F14 >= 2) {
-                    player->boostMeter += 2.0f;
-                } else {
-                    player->boostMeter += 1.0f;
-                }
+            if (D_800C9F14 >= 2) {
+                player->boostMeter += 2.0f;
+            } else {
+                player->boostMeter += 1.0f;
             }
             if (player->boostMeter > 90.0f) {
                 player->boostMeter = 90.0f;

--- a/src/overlays/ovl_i3/fox_aq.c
+++ b/src/overlays/ovl_i3/fox_aq.c
@@ -1531,12 +1531,10 @@ void Aquas_BlueMarineBoost(Player* player) {
                 }
                 
 
-                if (!CVarGetInteger("gInfiniteBoost", 0)) {
-                    player->boostMeter += 3.0f;
-                    if (player->boostMeter > 90.0f) {
-                        player->boostMeter = 90.0f;
-                        player->boostCooldown = 1;
-                    }
+                player->boostMeter += 3.0f;
+                if (player->boostMeter > 90.0f) {
+                    player->boostMeter = 90.0f;
+                    player->boostCooldown = 1;
                 }
 
                 player->boostSpeed += 2.0f;
@@ -1583,12 +1581,10 @@ void Aquas_BlueMarineBrake(Player* player) {
                 AUDIO_PLAY_SFX(NA_SE_MARINE_BRAKE, player->sfxSource, 4);
             }
 
-            if (!CVarGetInteger("gInfiniteBoost", 0)) {
-                player->boostMeter += 3.0f;
-                if (player->boostMeter > 90.0f) {
-                    player->boostMeter = 90.0f;
-                    player->boostCooldown = 1;
-                }
+            player->boostMeter += 3.0f;
+            if (player->boostMeter > 90.0f) {
+                player->boostMeter = 90.0f;
+                player->boostCooldown = 1;
             }
 
             player->boostSpeed -= 1.0f;

--- a/src/port/hooks/list/EngineEvent.h
+++ b/src/port/hooks/list/EngineEvent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "global.h"
 #include "port/hooks/impl/EventSystem.h"
 
 DEFINE_EVENT(DisplayPreUpdateEvent);
@@ -7,6 +8,9 @@ DEFINE_EVENT(DisplayPostUpdateEvent);
 
 DEFINE_EVENT(GamePreUpdateEvent);
 DEFINE_EVENT(GamePostUpdateEvent);
+
+DEFINE_EVENT(PlayerPreUpdateEvent, Player* player);
+DEFINE_EVENT(PlayerPostUpdateEvent, Player* player);
 
 DEFINE_EVENT(DrawRadarHUDEvent);
 DEFINE_EVENT(DrawBoostGaugeHUDEvent);

--- a/src/port/hooks/list/EngineEvent.h
+++ b/src/port/hooks/list/EngineEvent.h
@@ -9,8 +9,8 @@ DEFINE_EVENT(DisplayPostUpdateEvent);
 DEFINE_EVENT(GamePreUpdateEvent);
 DEFINE_EVENT(GamePostUpdateEvent);
 
-DEFINE_EVENT(PlayerPreUpdateEvent, Player* player);
-DEFINE_EVENT(PlayerPostUpdateEvent, Player* player);
+DEFINE_EVENT(PlayerPreUpdateEvent, Player* player;);
+DEFINE_EVENT(PlayerPostUpdateEvent, Player* player;);
 
 DEFINE_EVENT(DrawRadarHUDEvent);
 DEFINE_EVENT(DrawBoostGaugeHUDEvent);

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -157,12 +157,44 @@ void OnGameUpdatePost(IEvent* event) {
     }
 }
 
+void RefillBoostMeter(Player* player) {
+    if (player->boostMeter > 1.0f){
+        player->boostMeter = 1.0f;
+    }
+}
+void OnPlayerUpdatePost(PlayerPostUpdateEvent* event) {
+    if (CVarGetInteger("gInfiniteBoost", 0) == 1) {
+        if (event->player->boostSpeed < 0.0f) {
+            event->player->boostSpeed += 0.5f;
+            if (event->player->boostSpeed > 0.0f) {
+                event->player->boostSpeed = 0.0f;
+            }
+        }
+    }
+}
+
+void OnPlayerBoost(PlayerActionBoostEvent* event) {
+    if (CVarGetInteger("gInfiniteBoost", 0) == 1){
+        RefillBoostMeter(event->player);
+    }
+}
+void OnPlayerBrake(PlayerActionBrakeEvent* event) {
+    if (CVarGetInteger("gInfiniteBoost", 0) == 1){
+        RefillBoostMeter(event->player);
+    }
+}
+
 void PortEnhancements_Init() {
     PortEnhancements_Register();
 
     // Register event listeners
     REGISTER_LISTENER(DisplayPreUpdateEvent, OnDisplayUpdatePre, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(GamePostUpdateEvent, OnGameUpdatePost, EVENT_PRIORITY_NORMAL);
+    REGISTER_LISTENER(PlayerPostUpdateEvent, OnPlayerUpdatePost, EVENT_PRIORITY_NORMAL);
+
+    // Register Action listeners
+    REGISTER_LISTENER(PlayerActionBoostEvent, OnPlayerBoost, EVENT_PRIORITY_NORMAL);
+    REGISTER_LISTENER(PlayerActionBrakeEvent, OnPlayerBrake, EVENT_PRIORITY_NORMAL);
 }
 
 void PortEnhancements_Register() {
@@ -172,6 +204,9 @@ void PortEnhancements_Register() {
 
     REGISTER_EVENT(GamePreUpdateEvent);
     REGISTER_EVENT(GamePostUpdateEvent);
+
+    REGISTER_EVENT(PlayerPreUpdateEvent);
+    REGISTER_EVENT(PlayerPostUpdateEvent);
 
     REGISTER_EVENT(DrawRadarHUDEvent);
     REGISTER_EVENT(DrawBoostGaugeHUDEvent);


### PR DESCRIPTION
Simply the same feature, but now in hooks form.

I also added a new pair of events, for PlayerUpdate.
We need this separate from GameUpdate to avoid crashes with access to the player in events that should happen every frame of gameplay specifically.

Second attempt at #113 due to git shenanigans