### PR TITLE
Allow players to disable the Gorgon's screen flashes

### DIFF
--- a/src/engine/fox_effect.c
+++ b/src/engine/fox_effect.c
@@ -3786,7 +3786,9 @@ void Effect_Effect395_Update(Effect395* this) {
                     D_ctx_801779A8[0] = 50.0f;
                     if (this->unk_46 == 10) {
                         gFillScreenRed = gFillScreenGreen = gFillScreenBlue = 255;
-                        gFillScreenAlpha = gFillScreenAlphaTarget = 255;
+                        if (CVarGetInteger("gDisableGorgonFlash", 0) == 0){
+                            gFillScreenAlpha = gFillScreenAlphaTarget = 255;
+                        }
                         gFillScreenAlphaTarget = 0;
                         gFillScreenAlphaStep = 25;
                         gCameraShake = 50;

--- a/src/overlays/ovl_i3/fox_a6.c
+++ b/src/overlays/ovl_i3/fox_a6.c
@@ -830,8 +830,10 @@ void Area6_A6Gorgon_Update(A6Gorgon* this) {
         case 2:
             Math_SmoothStepToF(D_ctx_801779A8, 10.0f, 1.0f, 5.0f, 0.0f);
             if (this->timer_050 == 10) {
-                gFillScreenRed = gFillScreenGreen = gFillScreenBlue = 255;
-                gFillScreenAlpha = gFillScreenAlphaTarget = 255;
+                if (CVarGetInteger("gDisableGorgonFlash", 0) == 0) {
+                    gFillScreenRed = gFillScreenGreen = gFillScreenBlue = 255;
+                    gFillScreenAlpha = gFillScreenAlphaTarget = 255;
+                }
                 gFillScreenAlphaTarget = 0;
                 gFillScreenAlphaStep = 25;
                 gCameraShake = 50;

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -542,6 +542,14 @@ void DrawEnhancementsMenu() {
             ImGui::EndMenu();
         }
 
+        if (UIWidgets::BeginMenu("Accessibility")) { 
+            UIWidgets::CVarCheckbox("Disable Gorgon (Area 6 boss) screen flashes", "gDisableGorgonFlash", {
+                .tooltip = "Gorgon flashes the screen repeatedly when firing its beam or when teleporting, which causes eye pain for some players and may be harmful to those with photosensitivity.",
+                .defaultValue = false
+            });
+            ImGui::EndMenu();
+        }
+
         ImGui::EndMenu();
     }
 }


### PR DESCRIPTION
I've seen more than one player mention in the Discord that the Gorgon's flashes hurts their eyes. 
And apparently the official VC version actually also removed those flashes.

To be clear, this is about the full-screen white flashes that happen when the Gorgon is firing its beam and when the Gorgon teleports.