### PR TITLE
Bugfixes for Charged Shots in Rapid Fire mode

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -3367,7 +3367,7 @@ bool Player_UpdateLockOn(Player* player) {
         }
     }
 
-    if (gInputPress->button & A_BUTTON) {
+    if (gInputPress->button & (CVarGetInteger("gLtoCharge", 0) == 1 ? L_TRIG : A_BUTTON)) {
         for (i = 0; i < ARRAY_COUNT(gActors); i++) {
             if ((gActors[i].obj.status == OBJ_ACTIVE) && (gActors[i].lockOnTimers[player->num] != 0)) {
                 if ((gPlayerShots[14 - player->num].obj.status == SHOT_FREE) ||

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -305,6 +305,13 @@ void OnLivesCounterDraw(IEvent* ev){
     HUD_LivesCount2_Draw(258.0f, SCREEN_HEIGHT - 20, gLifeCount[gPlayerNum]);
 }
 
+void OnPlayerShootChargedPre(PlayerActionPreShootChargedEvent* ev){
+    if (CVarGetInteger("gRapidFire", 0) == 1) {
+        ev->player->shotTimer = 4;
+    }
+
+}
+
 void PortEnhancements_Init() {
     PortEnhancements_Register();
 
@@ -323,6 +330,7 @@ void PortEnhancements_Init() {
     REGISTER_LISTENER(PlayerActionBoostEvent, OnPlayerBoost, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(PlayerActionBrakeEvent, OnPlayerBrake, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(PlayerActionPostShootEvent, OnPlayerShootPost, EVENT_PRIORITY_NORMAL);
+    REGISTER_LISTENER(PlayerActionPreShootChargedEvent, OnPlayerShootChargedPre, EVENT_PRIORITY_NORMAL);
 }
 
 void PortEnhancements_Register() {


### PR DESCRIPTION
Adds a delay after firing a charged shot in Rapid Fire Mode (prevents an issue where a normal shot was fired in the same frame)
Uses L to shoot charged shots if `gLToCharge` is true