### PR TITLE
Prevent getting locked down with unitialized random seed

### DIFF
--- a/src/sys/sys_math.c
+++ b/src/sys/sys_math.c
@@ -19,6 +19,9 @@ void Rand_Init(void) {
 }
 
 f32 Rand_ZeroOne(void) {
+    if (sRandSeed1 == sRandSeed2 == sRandSeed3 == 0){
+        Rand_Init();
+    }
     sRandSeed1 = (sRandSeed1 * 171) % 30269;
     sRandSeed2 = (sRandSeed2 * 172) % 30307;
     sRandSeed3 = (sRandSeed3 * 170) % 30323;


### PR DESCRIPTION
In the Title Screen there is a `while` loop that is true while two values are the same, and changes one of them via `RAND_INT`. 
![image](https://github.com/user-attachments/assets/c47fe3c3-8e5b-48f3-b635-6a992bd5f7f0)

`RAND_INT` uses the `Rand_ZeroOne` function internally. 

For reasons unknown to me, sometimes all 3 random seeds are set to zero even if `Rand_Init` was already executed. Since `Rand_ZeroOne` only changes the seed values through multiplication and division, the result is always zero in that case. This causes the Title Screen `while` loop to be stuck indefinitely. 

I made a bandaid fix by checking the `sRandSeed`s for equality to zero, and re-run `Rand_Init` if so. 