### PR TITLE
Fix HUD elements where HUD Aspect was applied wrong

### DIFF
--- a/src/engine/fox_display.c
+++ b/src/engine/fox_display.c
@@ -92,10 +92,10 @@ void Display_DrawHelpAlert(void) {
         switch (centered) {
             case false:
                 if (gTeamHelpActor->sfxSource[0] > 0.0f) {
-                    sp78 = 20.0f * OTRGetAspectRatio() - 8;
+                    sp78 = 20.0f * OTRGetHUDAspectRatio() - 8;
                     sp74 = M_PI / 2;
                 } else {
-                    sp78 = -20.0f * OTRGetAspectRatio() + 8;
+                    sp78 = -20.0f * OTRGetHUDAspectRatio() + 8;
                     sp74 = -M_PI / 2;
                 }
                 Matrix_Push(&gGfxMatrix);
@@ -120,7 +120,7 @@ void Display_DrawHelpAlert(void) {
 
                 // @port: Tag the transform.
                 FrameInterpolation_RecordOpenChild("Display_DrawHelpAlert", centered);
-                Matrix_Translate(gGfxMatrix, 20.0f * OTRGetAspectRatio() - 8, 0.0f, -50.0f, MTXF_APPLY);
+                Matrix_Translate(gGfxMatrix, 20.0f * OTRGetHUDAspectRatio() - 8, 0.0f, -50.0f, MTXF_APPLY);
                 Matrix_RotateZ(gGfxMatrix, -M_PI / 2, MTXF_APPLY);
                 Matrix_Scale(gGfxMatrix, 0.03f, 0.03f, 0.03f, MTXF_APPLY);
                 Matrix_SetGfxMtx(&gMasterDisp);
@@ -130,7 +130,7 @@ void Display_DrawHelpAlert(void) {
 
                 // left arrow (both in simultaneous)
                 Matrix_Push(&gGfxMatrix);
-                Matrix_Translate(gGfxMatrix, -20.0f * OTRGetAspectRatio() + 8, 0.0f, -50.0f, MTXF_APPLY);
+                Matrix_Translate(gGfxMatrix, -20.0f * OTRGetHUDAspectRatio() + 8, 0.0f, -50.0f, MTXF_APPLY);
                 Matrix_RotateZ(gGfxMatrix, M_PI / 2, MTXF_APPLY);
                 Matrix_Scale(gGfxMatrix, 0.03f, 0.03f, 0.03f, MTXF_APPLY);
                 Matrix_SetGfxMtx(&gMasterDisp);
@@ -147,17 +147,17 @@ void Display_DrawHelpAlert(void) {
                 RCP_SetupDL(&gMasterDisp, SETUPDL_76_POINT);
                 gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 255, 255, 0, 255);
                 if (sp78 < 0.0f) {
-                    Graphics_DisplaySmallText(OTRGetRectDimensionFromLeftEdge(38.0f), 106, 1.0f, 1.0f, "HELP!!");
+                    Graphics_DisplaySmallText(OTRGetRectDimensionFromLeftEdgeOverride(38.0f), 106, 1.0f, 1.0f, "HELP!!");
                 } else {
-                    Graphics_DisplaySmallText(OTRGetRectDimensionFromRightEdge(248), 106, 1.0f, 1.0f, "HELP!!");
+                    Graphics_DisplaySmallText(OTRGetRectDimensionFromRightEdgeOverride(248), 106, 1.0f, 1.0f, "HELP!!");
                 }
                 break;
 
             case true:
                 RCP_SetupDL(&gMasterDisp, SETUPDL_76_POINT);
                 gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 255, 255, 0, 255);
-                Graphics_DisplaySmallText(OTRGetRectDimensionFromLeftEdge(38.0f), 106, 1.0f, 1.0f, "HELP!!");
-                Graphics_DisplaySmallText(OTRGetRectDimensionFromRightEdge(248), 106, 1.0f, 1.0f, "HELP!!");
+                Graphics_DisplaySmallText(OTRGetRectDimensionFromLeftEdgeOverride(38.0f), 106, 1.0f, 1.0f, "HELP!!");
+                Graphics_DisplaySmallText(OTRGetRectDimensionFromRightEdgeOverride(248), 106, 1.0f, 1.0f, "HELP!!");
                 break;
         }
     }

--- a/src/engine/fox_hud.c
+++ b/src/engine/fox_hud.c
@@ -2819,9 +2819,9 @@ void HUD_EdgeArrows_Draw(s32 idx, bool arg1) {
     f32 xPos = D_800D1EF8[idx];
 
     if (xPos < 0.0f) {
-        xPos = xPos * OTRGetAspectRatio() + 1;
+        xPos = xPos * OTRGetHUDAspectRatio() + 1;
     } else if (xPos > 0.0f) {
-        xPos = xPos * OTRGetAspectRatio() - 1;
+        xPos = xPos * OTRGetHUDAspectRatio() - 1;
     }
 
     if (arg1) {

--- a/src/engine/fox_hud.c
+++ b/src/engine/fox_hud.c
@@ -1498,8 +1498,8 @@ void HUD_PauseScreen_Update(void) {
                 sPauseScreenTimer[0] = 0;
 
             case 3:
-                Graphics_FillRectangle(&gMasterDisp, OTRGetRectDimensionFromLeftEdgeOverride(0), 0,
-                                       OTRGetDimensionFromRightEdgeOverride(SCREEN_WIDTH), SCREEN_HEIGHT, 0, 0, 0, 255);
+                Graphics_FillRectangle(&gMasterDisp, OTRGetRectDimensionFromLeftEdge(0), 0,
+                                       OTRGetDimensionFromRightEdge(SCREEN_WIDTH)+1, SCREEN_HEIGHT, 0, 0, 0, 255);
 
                 gFillScreenAlphaTarget = 0;
 
@@ -1548,8 +1548,8 @@ void HUD_PauseScreen_Update(void) {
                 break;
 
             case 4:
-                Graphics_FillRectangle(&gMasterDisp, OTRGetRectDimensionFromLeftEdgeOverride(0), 0,
-                                       OTRGetDimensionFromRightEdgeOverride(SCREEN_WIDTH), SCREEN_HEIGHT, 0, 0, 0, 255);
+                Graphics_FillRectangle(&gMasterDisp, OTRGetRectDimensionFromLeftEdge(0), 0,
+                                       OTRGetDimensionFromRightEdge(SCREEN_WIDTH)+1, SCREEN_HEIGHT, 0, 0, 0, 255);
                 if (sPauseScreenTimer[0] < 140) {
                     break;
                 }
@@ -1567,8 +1567,8 @@ void HUD_PauseScreen_Update(void) {
                 }
 
             case 5:
-                Graphics_FillRectangle(&gMasterDisp, OTRGetRectDimensionFromLeftEdgeOverride(0), 0,
-                                       OTRGetDimensionFromRightEdgeOverride(SCREEN_WIDTH), SCREEN_HEIGHT, 0, 0, 0, 255);
+                Graphics_FillRectangle(&gMasterDisp, OTRGetRectDimensionFromLeftEdge(0), 0,
+                                       OTRGetDimensionFromRightEdge(SCREEN_WIDTH)+1, SCREEN_HEIGHT, 0, 0, 0, 255);
 
                 for (i = 0; i < 6; i++) {
                     if (gPrevPlanetTeamShields[i] == -1) {

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -280,9 +280,9 @@ void OnBoostGaugeDraw(IEvent* event){
 
     RCP_SetupDL(&gMasterDisp, SETUPDL_76_POINT);
     gDPSetPrimColor(gMasterDisp++, 0, 0, 255, 255, 255, 255);
-    Lib_TextureRect_CI8(&gMasterDisp, D_1012290, D_10126B0, 48, 22, OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH - x), y, 1.0f, 1.0f);
-    Lib_TextureRect_CI8(&gMasterDisp, D_10126F0, D_1012750, 24, 4, OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH - (x - 9)), y + 3, 1.0f, 1.0f);
-    Lib_TextureRect_RGBA16(&gMasterDisp, sBoostGaugeArrow[step], 32, 32, OTRGetRectDimensionFromRightEdge(SCREEN_WIDTH - (x - 6)), y - 1, 0.9f, 0.9f);
+    Lib_TextureRect_CI8(&gMasterDisp, D_1012290, D_10126B0, 48, 22, OTRGetRectDimensionFromRightEdgeOverride(SCREEN_WIDTH - x), y, 1.0f, 1.0f);
+    Lib_TextureRect_CI8(&gMasterDisp, D_10126F0, D_1012750, 24, 4, OTRGetRectDimensionFromRightEdgeOverride(SCREEN_WIDTH - (x - 9)), y + 3, 1.0f, 1.0f);
+    Lib_TextureRect_RGBA16(&gMasterDisp, sBoostGaugeArrow[step], 32, 32, OTRGetRectDimensionFromRightEdgeOverride(SCREEN_WIDTH - (x - 6)), y - 1, 0.9f, 0.9f);
 }
 
 void OnBombCounterDraw(IEvent* ev){


### PR DESCRIPTION
Stop applying HUD Aspect Ratio to the black background of the death/restart screen

Apply HUD Aspect Ratio to "HELP!!" arrows, edge indicator arrows and the Beta Boost Gauge.