### PR TITLE
Allow customizing cockpit glass opacity

### DIFF
--- a/src/engine/fox_display.c
+++ b/src/engine/fox_display.c
@@ -699,7 +699,8 @@ void Display_CockpitGlass(void) {
     Matrix_Scale(gGfxMatrix, D_display_800CA28C, D_display_800CA28C, D_display_800CA28C, MTXF_APPLY);
     Matrix_SetGfxMtx(&gMasterDisp);
     RCP_SetupDL_64_2();
-    gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 255, 255, 255, 120);
+    u16 opacity = CVarGetInteger("gCockpitOpacity", 120);
+    gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 255, 255, 255, opacity);
     gSPClearGeometryMode(gMasterDisp++, G_CULL_BACK);
     gSPDisplayList(gMasterDisp++, D_arwing_30194E0);
     gSPSetGeometryMode(gMasterDisp++, G_CULL_BACK);

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -473,6 +473,8 @@ void DrawEnhancementsMenu() {
                 .tooltip = "Character heads are displayed inside Arwings in all cutscenes",
                 .defaultValue = true
             });
+            UIWidgets::CVarSliderInt("Cockpit Glass Opacity: %d", "gCockpitOpacity", 0, 255, 120);
+            
 
             ImGui::EndMenu();
         }


### PR DESCRIPTION
The default value, which is the value used in vanilla, is 120. Here's a comparison between 120 and 60:

![image](https://github.com/user-attachments/assets/3a309c84-2fd4-4e9c-a4cf-485fc308a40c)

![image](https://github.com/user-attachments/assets/b6aa9f42-e217-480e-987b-e475de583590)
