### PR TITLE
Add Debug Pause

### DIFF
--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -7161,8 +7161,9 @@ void Play_Main(void) {
             }
 
             gDrawMode = DRAW_PLAY;
-
-            Play_Update();
+            if (CVarGetInteger("gDebugPause", 0) == 0){
+                Play_Update();
+            }
 
             if ((gControllerPress[gMainController].button & START_BUTTON) &&
                 (gPlayer[0].state == PLAYERSTATE_LEVEL_INTRO) &&

--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -7161,7 +7161,7 @@ void Play_Main(void) {
             }
 
             gDrawMode = DRAW_PLAY;
-            if (CVarGetInteger("gDebugPause", 0) == 0){
+            CALL_CANCELLABLE_EVENT(PlayUpdateEvent){
                 Play_Update();
             }
 

--- a/src/port/hooks/list/EngineEvent.h
+++ b/src/port/hooks/list/EngineEvent.h
@@ -9,6 +9,8 @@ DEFINE_EVENT(DisplayPostUpdateEvent);
 DEFINE_EVENT(GamePreUpdateEvent);
 DEFINE_EVENT(GamePostUpdateEvent);
 
+DEFINE_EVENT(PlayUpdateEvent);
+
 DEFINE_EVENT(PlayerPreUpdateEvent, Player* player;);
 DEFINE_EVENT(PlayerPostUpdateEvent, Player* player;);
 

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -331,6 +331,9 @@ void PortEnhancements_Init() {
     REGISTER_LISTENER(PlayerActionBrakeEvent, OnPlayerBrake, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(PlayerActionPostShootEvent, OnPlayerShootPost, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(PlayerActionPreShootChargedEvent, OnPlayerShootChargedPre, EVENT_PRIORITY_NORMAL);
+
+    //If we close the game while debug pause is active, we want it to be deactivated when we run again.
+    CVarSetInteger("gDebugPause", 0);
 }
 
 void PortEnhancements_Register() {

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -163,6 +163,10 @@ void OnGameUpdatePost(IEvent* event) {
     }
 }
 
+void OnPlayUpdateEvent(IEvent* event){
+    event->cancelled = CVarGetInteger("gDebugPause", 0);
+}
+
 void RefillBoostMeter(Player* player) {
     if (player->boostMeter > 1.0f) {
         player->boostMeter = 1.0f;
@@ -318,6 +322,7 @@ void PortEnhancements_Init() {
     // Register event listeners
     REGISTER_LISTENER(DisplayPostUpdateEvent, OnDisplayUpdatePost, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(GamePostUpdateEvent, OnGameUpdatePost, EVENT_PRIORITY_NORMAL);
+    REGISTER_LISTENER(PlayUpdateEvent, OnPlayUpdateEvent, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(PlayerPostUpdateEvent, OnPlayerUpdatePost, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(DrawBoostGaugeHUDEvent, OnBoostGaugeDraw, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(DrawLivesCounterHUDEvent, OnLivesCounterDraw, EVENT_PRIORITY_NORMAL);
@@ -343,6 +348,8 @@ void PortEnhancements_Register() {
 
     REGISTER_EVENT(GamePreUpdateEvent);
     REGISTER_EVENT(GamePostUpdateEvent);
+
+    REGISTER_EVENT(PlayUpdateEvent);
 
     REGISTER_EVENT(PlayerPreUpdateEvent);
     REGISTER_EVENT(PlayerPostUpdateEvent);

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -711,6 +711,10 @@ void DrawDebugMenu() {
             .tooltip = "Jump to credits at the main menu"
         });
 
+        if (gGameState == GSTATE_PLAY){
+            UIWidgets::CVarCheckbox("Debug Pause", "gDebugPause");
+        }
+
         if (CVarGetInteger(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str(), 0)) {
             if (UIWidgets::Button("Clear Checkpoint")) {
                 CVarClear(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str());


### PR DESCRIPTION
This lets you pause the game loop without having to show the pause menu, and also works in cutscenes. 

I was using this when trying to work out why the arwing cockpits seem to not be correctly attached (I haven't figured it out, but now we have a new debug thingy)