### PR TITLE
Option to add outlines to ships in radar

### DIFF
--- a/src/engine/fox_hud.c
+++ b/src/engine/fox_hud.c
@@ -1789,19 +1789,49 @@ void HUD_RadarMark_Arwing_Draw(s32 colorIdx) {
     }
 
     RCP_SetupDL(&gMasterDisp, SETUPDL_62);
-    gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[colorIdx][0], arwingMarkColor[colorIdx][1],
-                    arwingMarkColor[colorIdx][2], arwingMarkColor[colorIdx][3]);
-    Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
-    Matrix_SetGfxMtx(&gMasterDisp);
-    gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
+    if (CVarGetInteger("gFighterOutlines", 0) == 1){
+        gDPSetPrimColor(gMasterDisp++, 0, 0,0,0,0,255);
+        Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
+        Matrix_SetGfxMtx(&gMasterDisp);
+        gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
+
+        gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[colorIdx][0], arwingMarkColor[colorIdx][1],
+                        arwingMarkColor[colorIdx][2], arwingMarkColor[colorIdx][3]);
+        Matrix_Translate(gGfxMatrix, 0.0f, 1.0f, 0.0f, MTXF_APPLY);
+        Matrix_Scale(gGfxMatrix, 0.8f, 0.7f, 1.0f, MTXF_APPLY);
+        Matrix_SetGfxMtx(&gMasterDisp);
+        gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
+    }
+    else{
+        gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[colorIdx][0], arwingMarkColor[colorIdx][1],
+            arwingMarkColor[colorIdx][2], arwingMarkColor[colorIdx][3]);
+        Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
+        Matrix_SetGfxMtx(&gMasterDisp);
+        gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
+
+    }
 }
 
 void HUD_RadarMark_StarWolf_Draw(void) {
     RCP_SetupDL(&gMasterDisp, SETUPDL_62);
-    gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
-    Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
-    Matrix_SetGfxMtx(&gMasterDisp);
-    gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
+        if (CVarGetInteger("gFighterOutlines", 0) == 1){
+        gDPSetPrimColor(gMasterDisp++, 0, 0, 255, 255, 255, 255);
+        Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
+        Matrix_SetGfxMtx(&gMasterDisp);
+        gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
+
+        gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
+        Matrix_Translate(gGfxMatrix, 0.0f, -1.2f, 0.0f, MTXF_APPLY);
+        Matrix_Scale(gGfxMatrix, 0.9f, 0.8f, 1.0f, MTXF_APPLY);
+        Matrix_SetGfxMtx(&gMasterDisp);
+        gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
+    }
+    else { 
+        gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
+        Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
+        Matrix_SetGfxMtx(&gMasterDisp);
+        gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);    
+    }
 }
 
 void HUD_RadarMark_Katt_Draw(void) {

--- a/src/engine/fox_hud.c
+++ b/src/engine/fox_hud.c
@@ -1789,49 +1789,19 @@ void HUD_RadarMark_Arwing_Draw(s32 colorIdx) {
     }
 
     RCP_SetupDL(&gMasterDisp, SETUPDL_62);
-    if (CVarGetInteger("gFighterOutlines", 0) == 1){
-        gDPSetPrimColor(gMasterDisp++, 0, 0,0,0,0,255);
-        Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
-        Matrix_SetGfxMtx(&gMasterDisp);
-        gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
-
-        gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[colorIdx][0], arwingMarkColor[colorIdx][1],
-                        arwingMarkColor[colorIdx][2], arwingMarkColor[colorIdx][3]);
-        Matrix_Translate(gGfxMatrix, 0.0f, 1.0f, 0.0f, MTXF_APPLY);
-        Matrix_Scale(gGfxMatrix, 0.8f, 0.7f, 1.0f, MTXF_APPLY);
-        Matrix_SetGfxMtx(&gMasterDisp);
-        gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
-    }
-    else{
-        gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[colorIdx][0], arwingMarkColor[colorIdx][1],
-            arwingMarkColor[colorIdx][2], arwingMarkColor[colorIdx][3]);
-        Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
-        Matrix_SetGfxMtx(&gMasterDisp);
-        gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
-
-    }
+    gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[colorIdx][0], arwingMarkColor[colorIdx][1],
+        arwingMarkColor[colorIdx][2], arwingMarkColor[colorIdx][3]);
+    Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
+    Matrix_SetGfxMtx(&gMasterDisp);
+    gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
 }
 
 void HUD_RadarMark_StarWolf_Draw(void) {
     RCP_SetupDL(&gMasterDisp, SETUPDL_62);
-        if (CVarGetInteger("gFighterOutlines", 0) == 1){
-        gDPSetPrimColor(gMasterDisp++, 0, 0, 255, 255, 255, 255);
-        Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
-        Matrix_SetGfxMtx(&gMasterDisp);
-        gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
-
-        gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
-        Matrix_Translate(gGfxMatrix, 0.0f, -1.2f, 0.0f, MTXF_APPLY);
-        Matrix_Scale(gGfxMatrix, 0.9f, 0.8f, 1.0f, MTXF_APPLY);
-        Matrix_SetGfxMtx(&gMasterDisp);
-        gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
-    }
-    else { 
-        gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
-        Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
-        Matrix_SetGfxMtx(&gMasterDisp);
-        gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);    
-    }
+    gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
+    Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
+    Matrix_SetGfxMtx(&gMasterDisp);
+    gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);    
 }
 
 void HUD_RadarMark_Katt_Draw(void) {
@@ -1915,17 +1885,21 @@ void HUD_RadarMark_Draw(s32 type) {
             } else {
                 arwingMarkColor = arwingMarkColor * 2;
             }
-
-            HUD_RadarMark_Arwing_Draw(arwingMarkColor);
+            CALL_CANCELLABLE_EVENT(DrawRadarMarkArwingEvent, arwingMarkColor) {
+                HUD_RadarMark_Arwing_Draw(arwingMarkColor);
+            }
             break;
 
         case RADARMARK_WOLF:
         case RADARMARK_LEON:
         case RADARMARK_PIGMA:
         case RADARMARK_ANDREW:
-            HUD_RadarMark_StarWolf_Draw();
-            break;
-
+            {   //This won't compile without braces, for some reason.
+                CALL_CANCELLABLE_EVENT(DrawRadarMarkWolfenEvent) {
+                    HUD_RadarMark_StarWolf_Draw();
+                }
+                break;
+            }
         case RADARMARK_KATT:
             HUD_RadarMark_Katt_Draw();
             break;

--- a/src/port/hooks/list/EngineEvent.h
+++ b/src/port/hooks/list/EngineEvent.h
@@ -13,7 +13,7 @@ DEFINE_EVENT(PlayerPreUpdateEvent, Player* player;);
 DEFINE_EVENT(PlayerPostUpdateEvent, Player* player;);
 
 DEFINE_EVENT(DrawRadarHUDEvent);
-DEFINE_EVENT(DrawRadarMarkArwingEvent, s32 colorIdx);
+DEFINE_EVENT(DrawRadarMarkArwingEvent, s32 colorIdx;);
 DEFINE_EVENT(DrawRadarMarkWolfenEvent);
 DEFINE_EVENT(DrawBoostGaugeHUDEvent);
 DEFINE_EVENT(DrawBombCounterHUDEvent);

--- a/src/port/hooks/list/EngineEvent.h
+++ b/src/port/hooks/list/EngineEvent.h
@@ -13,6 +13,8 @@ DEFINE_EVENT(PlayerPreUpdateEvent, Player* player;);
 DEFINE_EVENT(PlayerPostUpdateEvent, Player* player;);
 
 DEFINE_EVENT(DrawRadarHUDEvent);
+DEFINE_EVENT(DrawRadarMarkArwingEvent, s32 colorIdx);
+DEFINE_EVENT(DrawRadarMarkWolfenEvent);
 DEFINE_EVENT(DrawBoostGaugeHUDEvent);
 DEFINE_EVENT(DrawBombCounterHUDEvent);
 DEFINE_EVENT(DrawIncomingMsgHUDEvent);

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -3,6 +3,7 @@
 #include "hit64.h"
 #include "mods.h"
 #include "hud.h"
+#include "assets/ast_star_wolf.h"
 
 #define INIT_EVENT_IDS
 #include "port/hooks/Events.h"
@@ -295,6 +296,64 @@ void OnBombCounterDraw(IEvent* ev){
     HUD_BombCounter_Draw(253.0f, 18.0f);
 }
 
+void OnRadarMarkArwingDraw(DrawRadarMarkArwingEvent* ev){
+    bool outlines = CVarGetInteger("gFighterOutlines", 0);
+    if (!outlines){
+        return;
+    }
+
+    ev->event.cancelled = true;
+
+    s32 arwingMarkColor[][4] = {
+        { 177, 242, 12, 255 }, { 89, 121, 6, 128 }, { 90, 90, 255, 255 }, { 45, 45, 128, 128 },
+        { 0, 179, 67, 255 },   { 0, 90, 34, 128 },  { 255, 30, 0, 255 },  { 128, 15, 0, 128 },
+    };
+    f32 var_fv1;
+    f32 var_fv2;
+
+    if (gCamCount != 1) {
+        var_fv1 = 38.0f;
+        var_fv2 = 38.0f;
+    } else {
+        var_fv1 = 54.0f;
+        var_fv2 = 54.0f;
+    }
+
+    RCP_SetupDL(&gMasterDisp, SETUPDL_62);
+    gDPSetPrimColor(gMasterDisp++, 0, 0,0,0,0,255);
+    Matrix_Scale(gGfxMatrix, var_fv1, var_fv2, 1.0f, MTXF_APPLY);
+    Matrix_SetGfxMtx(&gMasterDisp);
+    gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
+
+    gDPSetPrimColor(gMasterDisp++, 0, 0, arwingMarkColor[ev->colorIdx][0], arwingMarkColor[ev->colorIdx][1],
+                    arwingMarkColor[ev->colorIdx][2], arwingMarkColor[ev->colorIdx][3]);
+    Matrix_Translate(gGfxMatrix, 0.0f, 1.0f, 0.0f, MTXF_APPLY);
+    Matrix_Scale(gGfxMatrix, 0.8f, 0.7f, 1.0f, MTXF_APPLY);
+    Matrix_SetGfxMtx(&gMasterDisp);
+    gSPDisplayList(gMasterDisp++, aRadarMarkArwingDL);
+    
+
+}
+
+void OnRadarMarkWolfenDraw(IEvent* ev) {
+    bool outlines = CVarGetInteger("gFighterOutlines", 0);
+    if (!outlines){
+        return;
+    }
+    ev->cancelled = true;
+
+    gDPSetPrimColor(gMasterDisp++, 0, 0, 255, 255, 255, 255);
+    Matrix_Scale(gGfxMatrix, 54.0f, 54.0f, 1.0f, MTXF_APPLY);
+    Matrix_SetGfxMtx(&gMasterDisp);
+    gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
+
+    gDPSetPrimColor(gMasterDisp++, 0, 0, 0, 0, 0, 255);
+    Matrix_Translate(gGfxMatrix, 0.0f, -1.2f, 0.0f, MTXF_APPLY);
+    Matrix_Scale(gGfxMatrix, 0.9f, 0.8f, 1.0f, MTXF_APPLY);
+    Matrix_SetGfxMtx(&gMasterDisp);
+    gSPDisplayList(gMasterDisp++, aStarWolfRadarMarkDL);
+}
+
 void OnLivesCounterDraw(IEvent* ev){
     bool restore = CVarGetInteger("gRestoreBetaBoostGauge", 0) == 1;
     if(!restore){
@@ -322,6 +381,8 @@ void PortEnhancements_Init() {
     REGISTER_LISTENER(DrawBoostGaugeHUDEvent, OnBoostGaugeDraw, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(DrawLivesCounterHUDEvent, OnLivesCounterDraw, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(DrawBombCounterHUDEvent, OnBombCounterDraw, EVENT_PRIORITY_NORMAL);
+    REGISTER_LISTENER(DrawRadarMarkArwingEvent, OnRadarMarkArwingDraw, EVENT_PRIORITY_NORMAL);
+    REGISTER_LISTENER(DrawRadarMarkWolfenEvent, OnRadarMarkWolfenDraw, EVENT_PRIORITY_NORMAL);
 
     REGISTER_LISTENER(ObjectUpdateEvent, OnItemGoldRingUpdate, EVENT_PRIORITY_NORMAL);
     REGISTER_LISTENER(ObjectDrawPostSetupEvent, OnItemGoldRingDraw, EVENT_PRIORITY_NORMAL);
@@ -345,6 +406,8 @@ void PortEnhancements_Register() {
     REGISTER_EVENT(PlayerPostUpdateEvent);
 
     REGISTER_EVENT(DrawRadarHUDEvent);
+    REGISTER_EVENT(DrawRadarMarkArwingEvent);
+    REGISTER_EVENT(DrawRadarMarkWolfenEvent);
     REGISTER_EVENT(DrawBoostGaugeHUDEvent);
     REGISTER_EVENT(DrawBombCounterHUDEvent);
     REGISTER_EVENT(DrawIncomingMsgHUDEvent);

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -566,6 +566,10 @@ void DrawEnhancementsMenu() {
                 .tooltip = "Gorgon flashes the screen repeatedly when firing its beam or when teleporting, which causes eye pain for some players and may be harmful to those with photosensitivity.",
                 .defaultValue = false
             });
+            UIWidgets::CVarCheckbox("Add outline to Arwing and Wolfen in radar", "gFighterOutlines", {
+                .tooltip = "Increases visibility of ships in the radar.",
+                .defaultValue = false
+            });
             ImGui::EndMenu();
         }
 


### PR DESCRIPTION
This increases visibility and is helpful for players with colorblindness. 
(It also looks much better with higher res texture packs)
![image](https://github.com/user-attachments/assets/b6949559-c6d5-4cfd-9e8b-6817f14d427d)
