### PR TITLE
Improve Debug Pause; Add frame-advance

### DIFF
--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -166,14 +166,20 @@ void OnGameUpdatePost(IEvent* event) {
 
 void OnPlayUpdateEvent(IEvent* event){
     bool debugPaused = CVarGetInteger("gDebugPause", 0);
+    bool shouldRepause = false;
     if (CVarGetInteger("gLToDebugPause", 0)){
         if (gControllerPress[0].button & L_TRIG) {
             CVarSetInteger("gDebugPause", !debugPaused);
+            shouldRepause = debugPaused && CVarGetInteger("gLToFrameAdvance", 0);
         } 
     } else {
         CVarSetInteger("gDebugPause", 0); //Unpause if we disable the shortcut
     }
+
     event->cancelled = CVarGetInteger("gDebugPause", 0);
+    if (shouldRepause){
+        CVarSetInteger("gDebugPause", 1);
+    }
 }
 
 void RefillBoostMeter(Player* player) {

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -165,6 +165,14 @@ void OnGameUpdatePost(IEvent* event) {
 }
 
 void OnPlayUpdateEvent(IEvent* event){
+    bool debugPaused = CVarGetInteger("gDebugPause", 0);
+    if (CVarGetInteger("gLToDebugPause", 0)){
+        if (gControllerPress[0].button & L_TRIG) {
+            CVarSetInteger("gDebugPause", !debugPaused);
+        } 
+    } else {
+        CVarSetInteger("gDebugPause", 0); //Unpause if we disable the shortcut
+    }
     event->cancelled = CVarGetInteger("gDebugPause", 0);
 }
 

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -718,9 +718,8 @@ void DrawDebugMenu() {
             .tooltip = "Jump to credits at the main menu"
         });
 
-        if (gGameState == GSTATE_PLAY){
-            UIWidgets::CVarCheckbox("Debug Pause", "gDebugPause");
-        }
+        UIWidgets::CVarCheckbox("Press L to Debug Pause", "gLToDebugPause");
+        
 
         if (CVarGetInteger(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str(), 0)) {
             if (UIWidgets::Button("Clear Checkpoint")) {

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -718,8 +718,12 @@ void DrawDebugMenu() {
             .tooltip = "Jump to credits at the main menu"
         });
 
-        UIWidgets::CVarCheckbox("Press L to Debug Pause", "gLToDebugPause");
-        
+        UIWidgets::CVarCheckbox("Press L to toggle Debug Pause", "gLToDebugPause");
+        if (CVarGetInteger("gLToDebugPause", 0)){
+            ImGui::Dummy(ImVec2(22.0f, 0.0f));
+            ImGui::SameLine();
+            UIWidgets::CVarCheckbox("Pressing L again advances one frame instead", "gLToFrameAdvance");
+        }
 
         if (CVarGetInteger(StringHelper::Sprintf("gCheckpoint.%d.Set", gCurrentLevel).c_str(), 0)) {
             if (UIWidgets::Button("Clear Checkpoint")) {


### PR DESCRIPTION
The checkbox now enables using the L button to toggle the debug pause. An additional checkbox also allows L to advance one frame from the paused state.