### PR TITLE
Remove jitter fix slider

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -509,11 +509,8 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
 
     time -= fps;
 
-    int threshold = CVarGetInteger("gExtraLatencyThreshold", 80);
-
     if (wnd != nullptr) {
         wnd->SetTargetFps(fps);
-        wnd->SetMaximumFrameLatency(threshold > 0 && target_fps >= threshold ? 2 : 1);
     }
 
     // When the gfx debugger is active, only run with the final mtx

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -348,12 +348,6 @@ void DrawSettingsMenu(){
         }
 
         UIWidgets::Tooltip("Matches interpolation value to the current game's window refresh rate");
-
-        if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-            UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 0) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
-                                                  "##ExtraLatencyThreshold", "gExtraLatencyThreshold", 0, 360, "", 0, true, true, false);
-            UIWidgets::Tooltip("When Interpolation FPS setting is at least this threshold, add one frame of input lag (e.g. 16.6 ms for 60 FPS) in order to avoid jitter. This setting allows the CPU to work on one frame while GPU works on the previous frame.\nThis setting should be used when your computer is too slow to do CPU + GPU work in time.");
-        }
       
         UIWidgets::PaddedSeparator(true, true, 3.0f, 3.0f);
 


### PR DESCRIPTION
LUS defaults to always on now (if not set by the port). And this option was confusing for most users.

Might increase input latency by one frame, when V-Sync is on and FPS is even above the refresh rate for a moment. (Normal behavior with jitter fix on).