### PR TITLE
Unify FPS and V-Sync controls and behavior

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -480,7 +480,7 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
     wnd->SetRendererUCode(UcodeHandlers::ucode_f3dex);
 
     std::vector<std::unordered_map<Mtx*, MtxF>> mtx_replacements;
-    int target_fps = CVarGetInteger("gInterpolationFPS", 60);
+    int target_fps = GameEngine::Instance->GetInterpolationFPS();
     static int last_fps;
     static int last_update_rate;
     static int time;
@@ -529,16 +529,16 @@ void GameEngine::ProcessGfxCommands(Gfx* commands) {
 }
 
 uint32_t GameEngine::GetInterpolationFPS() {
-    if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-        return CVarGetInteger("gInterpolationFPS", 60);
-    }
-
     if (CVarGetInteger("gMatchRefreshRate", 0)) {
         return Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
+
+    } else if (CVarGetInteger("gVsyncEnabled", 1) ||
+               !Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
+        return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(),
+                                  CVarGetInteger("gInterpolationFPS", 60));
     }
 
-    return std::min<uint32_t>(Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate(),
-                              CVarGetInteger("gInterpolationFPS", 60));
+    return CVarGetInteger("gInterpolationFPS", 60);
 }
 
 uint32_t GameEngine::GetInterpolationFrameCount()

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -246,12 +246,7 @@ void DrawSettingsMenu(){
 
         { // FPS Slider
             const int minFps = 30;
-            static int maxFps;
-            if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-                maxFps = 360;
-            } else {
-                maxFps = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-            }
+            static int maxFps = 360;
             int currentFps = 0;
         #ifdef __WIIU__
             UIWidgets::Spacer(0);
@@ -314,40 +309,20 @@ void DrawSettingsMenu(){
             CVarSetInteger("gInterpolationFPS", currentFps);
             Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
         #else
-            bool matchingRefreshRate =
-                CVarGetInteger("gMatchRefreshRate", 0) && Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() != Ship::WindowBackend::FAST3D_DXGI_DX11;
+            bool matchingRefreshRate = CVarGetInteger("gMatchRefreshRate", 0);
             UIWidgets::CVarSliderInt((currentFps == 30) ? "FPS: Original (30)" : "FPS: %d", "gInterpolationFPS", minFps, maxFps, 60, {
                 .disabled = matchingRefreshRate
             });
         #endif
-            if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-                UIWidgets::Tooltip(
-                    "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
-                    "visual and does not impact game logic, execution of glitches etc.\n\n"
-                    "A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse result."
-                );
-            } else {
-                UIWidgets::Tooltip(
-                    "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
-                    "visual and does not impact game logic, execution of glitches etc."
-                );
-            }
+            UIWidgets::Tooltip(
+                "Uses Matrix Interpolation to create extra frames, resulting in smoother graphics. This is purely "
+                "visual and does not impact game logic, execution of glitches etc.\n\n"
+                "A higher target FPS than your monitor's refresh rate will waste resources, and might give a worse result."
+            );
         } // END FPS Slider
 
-        if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
-            UIWidgets::Spacer(0);
-            if (ImGui::Button("Match Refresh Rate")) {
-                int hz = Ship::Context::GetInstance()->GetWindow()->GetCurrentRefreshRate();
-                if (hz >= 30 && hz <= 360) {
-                    CVarSetInteger("gInterpolationFPS", hz);
-                    Ship::Context::GetInstance()->GetWindow()->GetGui()->SaveConsoleVariablesNextFrame();
-                }
-            }
-        } else {
-            UIWidgets::PaddedEnhancementCheckbox("Match Refresh Rate", "gMatchRefreshRate", true, false);
-        }
-
-        UIWidgets::Tooltip("Matches interpolation value to the current game's window refresh rate");
+        UIWidgets::PaddedEnhancementCheckbox("Match Refresh Rate", "gMatchRefreshRate", true, false);
+        UIWidgets::Tooltip("Matches interpolation value to the refresh rate of your display.");
 
         if (Ship::Context::GetInstance()->GetWindow()->GetWindowBackend() == Ship::WindowBackend::FAST3D_DXGI_DX11) {
             UIWidgets::PaddedEnhancementSliderInt(CVarGetInteger("gExtraLatencyThreshold", 0) == 0 ? "Jitter fix: Off" : "Jitter fix: >= %d FPS",
@@ -394,6 +369,7 @@ void DrawSettingsMenu(){
 
         if (Ship::Context::GetInstance()->GetWindow()->CanDisableVerticalSync()) {
             UIWidgets::PaddedEnhancementCheckbox("Enable Vsync", "gVsyncEnabled", true, false);
+            UIWidgets::Tooltip("Removes tearing, but clamps your max FPS to your displays refresh rate.");
         }
 
         if (Ship::Context::GetInstance()->GetWindow()->SupportsWindowedFullscreen()) {


### PR DESCRIPTION
https://github.com/HarbourMasters/Shipwright/pull/5132 ported to starship

- DirectX's "Match Refresh Rate" is now a checkbox like in OpenGL and Metal.
- Clamp max FPS to refresh rate when V-Sync is enabled or can't be disabled, regardless of the FPS sliders setting, to avoid slowdown in Metal / OpenGL and dropping frames in DirectX as much as possible.
- FPS slider allows up to 360 FPS in every renderer.
- More descriptive V-Sync tooltip

Also fixes GetInterpolationFPS() not being used to calculate desired FPS.