### PR TITLE
Implement keyboard shortcut for reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Congratulations, you are now sailing with Starship! Have fun!
 | Keys | Action |
 | - | - |
 | F1 | Toggle menubar |
+| F4 | Reset |
 | F11 | Fullscreen |
 | Tab | Toggle Alternate assets |
-| Ctrl+R | Reset |
 
 ### Graphics Backends
 Currently, there are three rendering APIs supported: DirectX11 (Windows), OpenGL (all platforms), and Metal (macOS). You can change which API to use in the `Settings` menu of the menubar, which requires a restart.  If you're having an issue with crashing, you can change the API in the `starship.cfg.json` file by finding the line `"Backend":{`... and changing the `id` value to `3` and set the `Name` to `OpenGL`. `DirectX 11` with id `2` is the default on Windows. `Metal` with id `4` is the default on macOS.

--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -326,6 +326,10 @@ void GameEngine::StartFrame() const {
             CVarSetInteger("gEnhancements.Mods.AlternateAssets", !CVarGetInteger("gEnhancements.Mods.AlternateAssets", 0));
             break;
         }
+        case KbScancode::LUS_KB_F4: {
+            gNextGameState = GSTATE_BOOT;
+            break;
+        }
         default:
             break;
     }

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -423,13 +423,7 @@ void DrawMenuBarIcon() {
 
 void DrawGameMenu() {
     if (UIWidgets::BeginMenu("Starship")) {
-        if (UIWidgets::MenuItem("Reset",
-#ifdef __APPLE__
-                "Command-R"
-#else
-                "Ctrl+R"
-#endif
-        )) {
+        if (UIWidgets::MenuItem("Reset", "F4")) {
             gNextGameState = GSTATE_BOOT;
         }
 #if !defined(__SWITCH__) && !defined(__WIIU__)


### PR DESCRIPTION
I found that the shortcut for resetting (`CTRL`+`R`) was not actually being handled anywhere. I'm not sure if this is something that was handled elsewhere and was removed, but it seems like there's no way of handling combination key presses so I'm not sure how this would have been previously implemented.

This fixes #185 (at least for the reset, I'm not sure what the F9 shortcut is supposed to be) by changing the shortcut for resetting the game and handling that shortcut. I had a solution that used the existing `CTRL`+`R` shortcut but handling combination key presses was more complicated.

Feel free to close if this is better handled elsewhere.