### PR TITLE
Fixed starship.o2r load on Linux

### DIFF
--- a/src/port/Engine.cpp
+++ b/src/port/Engine.cpp
@@ -70,7 +70,7 @@ GameEngine::GameEngine() {
 
     std::vector<std::string> archiveFiles;
     const std::string main_path = Ship::Context::GetPathRelativeToAppDirectory("sf64.o2r");
-    const std::string assets_path = Ship::Context::GetPathRelativeToAppDirectory("starship.o2r");
+    const std::string assets_path = Ship::Context::GetPathRelativeToAppBundle("starship.o2r");
 
 #ifdef _WIN32
     AllocConsole();


### PR DESCRIPTION
Noticed the file was still in the bundle for the appimage so figured it might just be loading it incorrectly, applied what 2ship does to handle its asset file and it worked.