### PR TITLE
JP/EU ROM selection closes game if no ROM selected.

### DIFF
--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -320,13 +320,10 @@ void DrawSettingsMenu(){
                     };
                 } else {
                     if (UIWidgets::Button("Install JP/EU Audio")) {
-                        if (GameEngine::GenAssetFile()){
+                        if (GameEngine::GenAssetFile(false)){
                             GameEngine::ShowMessage("Success", "Audio assets installed. Changes will be applied on the next startup.", SDL_MESSAGEBOX_INFORMATION);
-                            Ship::Context::GetInstance()->GetWindow()->Close();
-                        } else {
-                            GameEngine::ShowMessage("Failure", "No ROM selected, exiting game...", SDL_MESSAGEBOX_INFORMATION);
-                            Ship::Context::GetInstance()->GetWindow()->Close();
                         }
+                        Ship::Context::GetInstance()->GetWindow()->Close();
                     }
                 }
                 ImGui::EndMenu();

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -323,6 +323,9 @@ void DrawSettingsMenu(){
                         if (GameEngine::GenAssetFile()){
                             GameEngine::ShowMessage("Success", "Audio assets installed. Changes will be applied on the next startup.", SDL_MESSAGEBOX_INFORMATION);
                             Ship::Context::GetInstance()->GetWindow()->Close();
+                        } else {
+                            GameEngine::ShowMessage("Failure", "No ROM selected, exiting game...", SDL_MESSAGEBOX_INFORMATION);
+                            Ship::Context::GetInstance()->GetWindow()->Close();
                         }
                     }
                 }


### PR DESCRIPTION
The game would hang without closing if no ROM was selected. Now with this change it will exit the game like the error message suggests it should.