### PR TITLE
Remove -mfpu option in CMakeLists.txt for aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,6 +543,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
           >
           -pthread
       )
+      
+      set(CPU_OPTION -mfpu=neon)
 
       target_link_options(${PROJECT_NAME} PRIVATE
           -pthread


### PR DESCRIPTION
When building for linux aarch64 I received `clang-18: error: unsupported option '-mfpu=' for target 'aarch64-unknown-linux-gnu'`. Removing lines 573 and 574 in CMakeLists.txt resolved the error and allowed compiling. I believe the `-mfpu` option is unsupported in aarch64 and some compilers fail to properly ignore it.

https://developer.arm.com/documentation/dui0774/l/Compiler-Command-line-Options/-mfpu