### PR TITLE
Set mcpu instead of mfpu in aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
       if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
         set(CPU_OPTION -msse2 -mfpmath=sse)
       elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-        set(CPU_OPTION -mfpu=native)
+        set(CPU_OPTION -mcpu=native)
       endif()
 
       target_compile_options(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
According to documentation:
https://developer.arm.com/documentation/dui0774/l/Compiler-Command-line-Options/-mfpu
https://stackoverflow.com/questions/72319839/aarch64-gcc-equivalent-option-for-mfpu-neon

`-mfpu=neon` is already set in aarch64 environments and while GCC *might* ignore the option, clang outright errors and refuses to build. When using WSL chroot to build with both GCC and clang, `-mcpu=native` falls back to a generic aarch64 processor. When building on known processors like `cortex-a57`, the switch should properly adapt.

Allows successful building for aarch64.