### PR TITLE
Rename same definition of `SF64::ObjectInit`

### DIFF
--- a/src/port/resource/importers/ObjectInitFactory.cpp
+++ b/src/port/resource/importers/ObjectInitFactory.cpp
@@ -12,7 +12,7 @@ std::shared_ptr<Ship::IResource> ResourceFactoryBinaryObjectInitV0::ReadResource
         return nullptr;
     }
 
-    auto obj = std::make_shared<ObjectInit>(initData);
+    auto obj = std::make_shared<ObjectInitResource>(initData);
     auto reader = std::get<std::shared_ptr<Ship::BinaryReader>>(file->Reader);
     auto count = reader->ReadUInt32();
 

--- a/src/port/resource/type/ObjectInit.cpp
+++ b/src/port/resource/type/ObjectInit.cpp
@@ -1,11 +1,11 @@
 #include "ObjectInit.h"
 
 namespace SF64 {
-ObjectInitData* ObjectInit::GetPointer() {
+ObjectInitData* ObjectInitResource::GetPointer() {
     return mObjects.data();
 }
 
-size_t ObjectInit::GetPointerSize() {
+size_t ObjectInitResource::GetPointerSize() {
     return sizeof(ObjectInitData) * mObjects.size();
 }
 }

--- a/src/port/resource/type/ObjectInit.h
+++ b/src/port/resource/type/ObjectInit.h
@@ -16,11 +16,12 @@ struct ObjectInitData {
     /* 0x10 */ int16_t id;
 }; // size = 0x14
 
-class ObjectInit : public Ship::Resource<ObjectInitData> {
+// Renamed from ObjectInit to prevent clashing with Torch of same namespace
+class ObjectInitResource : public Ship::Resource<ObjectInitData> {
   public:
     using Resource::Resource;
 
-    ObjectInit() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
+    ObjectInitResource() : Resource(std::shared_ptr<Ship::ResourceInitData>()) {}
 
     ObjectInitData* GetPointer();
     size_t GetPointerSize();


### PR DESCRIPTION
`SF64::ObjectInit` defined as a class located in `src/port/resource/type/ObjectInit.h` clashes with the same name in `tools/Torch/src/factories/sf64/ObjInitFactory.h` except it's defined as struct and has the same members as ObjectInitData. This might cause some compilers to get confused whether to use either for usage on constructor/destructor. This patch renames the class name in src/port/resource.