### PR TITLE
Add Nova Laser upgrade tier beyond Hyper Laser

### DIFF
--- a/include/sf64event.h
+++ b/include/sf64event.h
@@ -255,7 +255,7 @@ typedef enum EventCondition {
     /* 35 */ EVC_SINGLE_LASER,
     /* 36 */ EVC_TWIN_LASER,
     /* 37 */ EVC_HYPER_LASER,
-    /* 38 */ EVC_UNK3_LASER,
+    /* 38 */ EVC_NOVA_LASER,
     /* 39 */ EVC_SHOT_CLOSE_150,
     /* 40 */ EVC_SHOT_CLOSE_300,
     /* 41 */ EVC_NO_LEADER,

--- a/include/sf64player.h
+++ b/include/sf64player.h
@@ -111,7 +111,7 @@ typedef enum LaserStrength {
     /* 0 */ LASERS_SINGLE,
     /* 1 */ LASERS_TWIN,
     /* 2 */ LASERS_HYPER,
-    /* 3 */ LASERS_UNK_3,
+    /* 3 */ LASERS_NOVA,
     /* 4 */ LASERS_MAX,
 } LaserStrength;
 

--- a/src/engine/fox_beam.c
+++ b/src/engine/fox_beam.c
@@ -675,6 +675,9 @@ void PlayerShot_ApplyDamageToActor(PlayerShot* shot, Actor* actor, s32 hitIndex)
             case LASERS_HYPER:
                 actor->damage = 15;
                 break;
+            case LASERS_NOVA:
+                actor->damage = 22;
+                break;
         }
     } else if ((shot->sourceId >= NPC_SHOT_ID) && (gCurrentLevel == LEVEL_SECTOR_X)) {
         if ((gActors[shot->sourceId - NPC_SHOT_ID].obj.id == OBJ_ACTOR_EVENT) &&
@@ -1027,6 +1030,9 @@ void PlayerShot_CollisionCheck(PlayerShot* shot) {
                                     case LASERS_HYPER:
                                         boss->damage = 15;
                                         break;
+                                    case LASERS_NOVA:
+                                        boss->damage = 22;
+                                        break;
                                 }
                             }
                         }
@@ -1120,6 +1126,9 @@ void PlayerShot_DrawLaser(PlayerShot* shot) {
                 case LASERS_HYPER:
                     dList = D_101AD20;
                     break;
+                case LASERS_NOVA:
+                    dList = D_101AD20;
+                    break;
             }
             if (gCurrentLevel == LEVEL_AQUAS) {
                 twinLaserSeparation = 4.0f;
@@ -1129,9 +1138,17 @@ void PlayerShot_DrawLaser(PlayerShot* shot) {
             Matrix_Translate(gGfxMatrix, twinLaserSeparation, 0.f, 0.0f, MTXF_APPLY);
             Matrix_SetGfxMtx(&gMasterDisp);
             gSPDisplayList(gMasterDisp++, dList);
+            if (gLaserStrength[0] == LASERS_NOVA) {
+                gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 180, 0, 255, 255);
+                gDPSetEnvColor(gMasterDisp++, 120, 0, 200, 255);
+            }
             Matrix_Translate(gGfxMatrix, -(2.0f * twinLaserSeparation), 0.0f, 0.f, MTXF_APPLY);
             Matrix_SetGfxMtx(&gMasterDisp);
             gSPDisplayList(gMasterDisp++, dList);
+            if (gLaserStrength[0] == LASERS_NOVA) {
+                gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 180, 0, 255, 255);
+                gDPSetEnvColor(gMasterDisp++, 120, 0, 200, 255);
+            }
         } else {
             var_a1 = 0;
             if ((gCurrentLevel != LEVEL_KATINA) && (shot->sourceId > NPC_SHOT_ID + AI360_PEPPY) &&

--- a/src/engine/fox_display.c
+++ b/src/engine/fox_display.c
@@ -1166,14 +1166,18 @@ void Display_ArwingLaserCharge(Player* player) {
                 FrameInterpolation_RecordCloseChild();
                 break;
 
-            case LASERS_TWIN:
+           case LASERS_TWIN:
             case LASERS_HYPER:
+            case LASERS_NOVA:
                 if (laserStrength == LASERS_TWIN) {
                     gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 192, 255, 192, 128);
                     gDPSetEnvColor(gMasterDisp++, 64, 255, 64, 128);
-                } else {
+                } else if (laserStrength == LASERS_HYPER) {
                     gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 128, 255, 255, 160);
                     gDPSetEnvColor(gMasterDisp++, 128, 128, 255, 160);
+                } else {
+                    gDPSetPrimColor(gMasterDisp++, 0x00, 0x00, 180, 64, 255, 200);
+                    gDPSetEnvColor(gMasterDisp++, 120, 0, 255, 200);
                 }
                 Matrix_MultVec3f(gCalcMatrix, &spAC, &sp94);
                 Matrix_MultVec3f(gCalcMatrix, &spA0, &sp88);

--- a/src/engine/fox_enmy.c
+++ b/src/engine/fox_enmy.c
@@ -2251,8 +2251,8 @@ void ItemPickup_Update(Item* this) {
                     this->unk_50 = 60.0f;
 
                     gLaserStrength[this->playerNum]++;
-                    if (gLaserStrength[this->playerNum] > LASERS_HYPER) {
-                        gLaserStrength[this->playerNum] = LASERS_HYPER;
+                    if (gLaserStrength[this->playerNum] > LASERS_NOVA) {
+                        gLaserStrength[this->playerNum] = LASERS_NOVA;
                     }
 
                     Object_PlayerSfx(gPlayer[this->playerNum].sfxSource, NA_SE_TWIN_LASER_GET, this->playerNum);

--- a/src/engine/fox_enmy2.c
+++ b/src/engine/fox_enmy2.c
@@ -2597,8 +2597,8 @@ void ActorEvent_ProcessTriggers(ActorEvent* this) {
             }
             break;
 
-        case EVC_UNK3_LASER:
-            if ((gPlayer[0].arwing.laserGunsYpos < -8.0f) && (gLaserStrength[0] == LASERS_UNK_3)) {
+       case EVC_NOVA_LASER:
+            if ((gPlayer[0].arwing.laserGunsYpos < -8.0f) && (gLaserStrength[0] == LASERS_NOVA)) {
                 ActorEvent_TriggerBranch(this);
             }
             break;

--- a/src/engine/fox_play.c
+++ b/src/engine/fox_play.c
@@ -3189,6 +3189,7 @@ void Player_ArwingLaser(Player* player) {
             break;
         case LASERS_TWIN:
         case LASERS_HYPER:
+        case LASERS_NOVA:
             for (i = 0; i < ARRAY_COUNT(gPlayerShots) - 1; i++) {
                 if (gPlayerShots[i].obj.status == SHOT_FREE) {
                     Player_SetupArwingShot(player, &gPlayerShots[i], 0.0f, -10.0f, PLAYERSHOT_TWIN_LASER,
@@ -3196,9 +3197,12 @@ void Player_ArwingLaser(Player* player) {
                     if (laser == LASERS_TWIN) {
                         Player_PlaySfx(player->sfxSource, NA_SE_ARWING_TWIN_LASER, player->num);
                         gMuzzleFlashScale[player->num] = 0.5f;
-                    } else {
+                    } else if (laser == LASERS_HYPER) {
                         Player_PlaySfx(player->sfxSource, NA_SE_ARWING_TWIN_LASER2, player->num);
                         gMuzzleFlashScale[player->num] = 0.75f;
+                    } else {
+                        Player_PlaySfx(player->sfxSource, NA_SE_ARWING_TWIN_LASER2, player->num);
+                        gMuzzleFlashScale[player->num] = 1.0f;
                     }
                     break;
                 }
@@ -3207,7 +3211,6 @@ void Player_ArwingLaser(Player* player) {
     }
     CALL_EVENT(PlayerActionPostShootEvent, player, &gPlayerShots[i]);
 }
-
 void Player_SmartBomb(Player* player) {
 
     if ((gBombCount[player->num] != 0) && (gBombButton[player->num] & gInputPress->button) &&

--- a/src/port/mods/PortEnhancements.c
+++ b/src/port/mods/PortEnhancements.c
@@ -133,11 +133,11 @@ void OnDisplayUpdatePost(IEvent* event) {
         gBombCount[0] = 9;
     }
 
-    if (CVarGetInteger("gHyperLaser", 0) == 1) {
+    if (CVarGetInteger("gNovaLaser", 0) == 1) {
         if ((gGameState != GSTATE_PLAY) || (gPlayState <= PLAY_INIT)) {
             return;
         }
-        gLaserStrength[0] = LASERS_HYPER;
+        gLaserStrength[0] = LASERS_NOVA;
     }
 
     if (CVarGetInteger("gScoreEditor", 0) == 1) {

--- a/src/port/ui/ImguiUI.cpp
+++ b/src/port/ui/ImguiUI.cpp
@@ -718,6 +718,7 @@ void DrawCheatsMenu() {
         UIWidgets::CVarCheckbox("Infinite Bombs", "gInfiniteBombs");
         UIWidgets::CVarCheckbox("Infinite Boost/Brake", "gInfiniteBoost");
         UIWidgets::CVarCheckbox("Hyper Laser", "gHyperLaser");
+        UIWidgets::CVarCheckbox("Nova Laser", "gNovaLaser");
         UIWidgets::CVarSliderInt("Laser Range Multiplier: %d%%", "gLaserRangeMult", 15, 800, 100,
             { .tooltip = "Changes how far your lasers fly." });
         UIWidgets::CVarCheckbox("Rapid-fire mode", "gRapidFire", {


### PR DESCRIPTION
## Nova Laser

This PR adds a new fourth laser upgrade tier called the Nova Laser, 
slotting into the previously unused LASERS_UNK_3 slot the original 
devs left in the code.

### Changes
- Renamed LASERS_UNK_3 to LASERS_NOVA in sf64player.h
- Renamed EVC_UNK3_LASER to EVC_NOVA_LASER in sf64event.h
- Nova Laser does 22 damage (1.5x Hyper Laser's 15)
- Proper pickup progression: Single → Twin → Hyper → Nova
- Purple muzzle flash with larger scale than Hyper
- Bigger muzzle flash scale (1.0f vs Hyper's 0.75f)
- Added gNovaLaser cheat toggle in PortEnhancements.c
- Added Nova Laser checkbox to the cheat menu in ImguiUI.cpp

### Notes
- Nova Laser reuses Hyper's beam display list
- The unused LASERS_UNK_3 slot suggests the original devs 
  may have planned a fourth laser tier