### PR TITLE
Update devkitpro version used in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
     needs: generate-port-o2r
     runs-on: ubuntu-latest
     container:
-      image: devkitpro/devkita64:20241023
+      image: devkitpro/devkita64:20260219
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/switch.yml
+++ b/.github/workflows/switch.yml
@@ -8,7 +8,7 @@ jobs:
   build-switch:
     runs-on: ubuntu-latest
     container:
-      image: devkitpro/devkita64:20241023
+      image: devkitpro/devkita64:20260219
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Recent updates to switch homebrew have broken programs built with older versions of devkit