### PR TITLE
Fix Info.plist version (0.1.0 → 2.0.0) to match project version

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleExecutable</key>
     <string>Starship</string>
     <key>CFBundleGetInfoString</key>
-    <string>0.1.0</string>
+    <string>2.0.0</string>
     <key>CFBundleIconFile</key>
     <string>Starship.icns</string>
     <key>CFBundleIdentifier</key>
@@ -22,11 +22,11 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>2.0.0</string>
     <key>CFBundleSignature</key>
     <string>ZMM</string>
     <key>CFBundleVersion</key>
-    <string>0.1.0</string>
+    <string>2.0.0</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2024 HarbourMasters.</string>
     <key>LSApplicationCategoryType</key>


### PR DESCRIPTION
The version keys in Info.plist are still 0.1.0 while the project is at 2.0.0 (project(Starship VERSION 2.0.0 ...)). The macOS .app uses this plist, so it reports the wrong version in Finder Get Info / About. This bumps CFBundleGetInfoString, CFBundleShortVersionString, and CFBundleVersion to 2.0.0. One file, branched off current main.