### PR TITLE
macOS: add sdl3 dependency (Homebrew sdl2 is sdl2-compat)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 brew "sdl2"
+brew "sdl3" # Homebrew's sdl2 is sdl2-compat, which loads SDL3 at runtime
 brew "libpng"
 brew "glew"
 brew "libzip"

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -166,7 +166,7 @@ cmake --build build-cmake --target clean
 ```
 
 ## macOS
-Requires Xcode (or xcode-tools) && `sdl2, libpng, glew, ninja, cmake, nlohmann-json, tinyxml2, libzip, vorbis-tools` (can be installed via homebrew, macports, etc)
+Requires Xcode (or xcode-tools) && `sdl2, sdl3, libpng, glew, ninja, cmake, nlohmann-json, tinyxml2, libzip, vorbis-tools` (can be installed via homebrew, macports, etc). `sdl3` is needed because modern Homebrew's `sdl2` is sdl2-compat, which loads SDL3 at runtime.
 
 **Important: For maximum performance make sure you have ninja build tools installed!**
 


### PR DESCRIPTION
### Problem
On a current Homebrew, the `sdl2` formula is **sdl2-compat** — a compatibility shim that doesn't contain SDL itself but `dlopen`s the real **SDL3** at runtime. So a macOS build that only installs `sdl2` links/builds fine but the resulting app needs `libSDL3.dylib` present to run.

### Fix
Add `sdl3` to the `Brewfile` and to the macOS dependency list in `docs/BUILDING.md`, so a fresh macOS build has SDL3 available at runtime.

Two-line change; no build-system changes.
